### PR TITLE
Improved dstat output (support for json and yaml).

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ foundation for use by the wider batch computing community.
 
 1.  Install dependent libraries.
 
-        pip install --upgrade oauth2client==1.5.2 google-api-python-client python-dateutil pytz tabulate
+        pip install --upgrade oauth2client==1.5.2 google-api-python-client python-dateutil pytz pyyaml tabulate
 
 1.  Verify the installation by running:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,22 +120,104 @@ my-job-name     task-3  running-docker  2017-04-11 16:24:39
 
 ## Getting detailed job information
 
-The default output from `dstat` is brief. To see more details,
-use the `--full` flag:
+The default output from `dstat` is brief tabular text, fit for display on an
+80 character terminal. The number of columns is small and column values may
+be truncated for space.
+
+`dstat` also supports a `full` output format. When the `--full` flag is used,
+the output automatically changes to [YAML](http://yaml.org/) which is
+"a human friendly data serialization standard" and more appropriate for
+detailed output.
+
+You can use the `--full` and `--format` parameters together to get the output
+you want. `--format` supports the values `json`, `text`, and `yaml`.
+
+### Full output (default format YAML)
 
 ```
 $ ./dstat --project my-project \
   --jobs my-job-id \
   --full
-Job Name        Status    Last Update          Created              Ended    User      Job ID                                  Internal ID                                                         Inputs
---------------  --------  -------------------  -------------------  -------  --------  --------------------------------------  ------------------------------------------------------------------  --------------------------------------------------
-my-job-name     Pending   2017-04-11 16:47:06  2017-04-11 16:47:06  NA       <userid>  my-job-id                               operations/OPERATION-ID                                             _SCRIPT=#!/bin/bash
+- create-time: '2017-04-11 16:47:06'
+  end-time: '2017-04-11 16:51:38'
+  inputs:
+    INPUT_PATH: gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam
+    _SCRIPT: |+
+      #!/bin/bash
 
-# Copyright 2016 Google In...
+      # Copyright 2016 Google Inc. All Rights Reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+<trimmed for brevity>
+      readonly INPUT_FILE_LIST="$(ls "${INPUT_PATH}")"
+
+      for INPUT_FILE in "${INPUT_FILE_LIST[@]}"; do
+        FILE_NAME="$(basename "${INPUT_FILE}")"
+
+        md5sum "${INPUT_FILE}" | awk '{ print $1 }' > "${OUTPUT_DIR}/${FILE_NAME}.md5"
+      done
+
+  internal-id: operations/OPERATION-ID
+  job-id: my-job-id
+  job-name: my-job-name
+  last-update: '2017-04-11 16:51:38'
+  outputs:
+    OUTPUT_PATH: gs://my-bucket/path/output
+  status: Success
+  user-id: my-user
 ```
 
 Note the `Internal ID` in this example provides the
 [Google Pipelines API operation name](https://cloud.google.com/genomics/reference/rest/v1alpha2/operations#name).
+
+### Full output as tabular text
+
+```
+$ ./dstat --project my-project \
+  --jobs my-job-id \
+  --format text \
+  --full
+Job ID                                  Job Name        Status    Last Update          Created              Ended                User      Internal ID                                                         Inputs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  Outputs
+--------------------------------------  --------------  --------  -------------------  -------------------  -------------------  --------  ------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  -------------------------------------------------------
+my-job-id                               my-job-name     Success   2017-04-11 16:51:38  2017-04-11 16:47:06  2017-04-11 16:51:38  my-user   operations/OPERATION-ID                                             INPUT_PATH=gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam, _SCRIPT=#!/bin/bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+<trimmed for brevity>
+for INPUT_FILE in "${INPUT_FILE_LIST[@]}"; do
+  FILE_NAME="$(basename "${INPUT_FILE}")"
+
+  md5sum "${INPUT_FILE}" | awk '{ print $1 }' > "${OUTPUT_DIR}/${FILE_NAME}.md5"
+done  OUTPUT_PATH=gs://my-bucket/path/output
+```
+
+### Full output as JSON
+
+```
+$ ./dstat --project my-project \
+  --jobs my-job-id \
+  --format json \
+  --full
+[
+  {
+    "status": "Success",
+    "inputs": {
+      "_SCRIPT": "#!/bin/bash\n\n# Copyright 2016 Google Inc. All Rights Reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n<trimmed for brevity>for INPUT_FILE in \"${INPUT_FILE_LIST[@]}\"; do\n  FILE_NAME=\"$(basename \"${INPUT_FILE}\")\"\n\n  md5sum \"${INPUT_FILE}\" | awk '{ print $1 }' > \"${OUTPUT_DIR}/${FILE_NAME}.md5\"\ndone\n\n", 
+      "INPUT_PATH": "gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam"
+    },
+    "job-name": "my-job-name",
+    "outputs": {
+      "OUTPUT_PATH": "gs://my-bucket/path/output"
+    },
+    "create-time": "2017-04-11 16:47:06",
+    "end-time": "2017-04-11 16:51:38",
+    "internal-id": "operations/OPERATION-ID",
+    "last-update": "2017-04-11 16:51:38",
+    "user-id": "my-user",
+    "job-id": "my-job-id"
+  }
+]
+```
 
 ## Viewing logs
 

--- a/lib/param_util.py
+++ b/lib/param_util.py
@@ -87,7 +87,7 @@ class OutputFileParam(FileParam):
   """Simple typed-derivative of a FileParam."""
 
   def __new__(cls, name, docker_path=None, remote_uri=None, recursive=False):
-    validate_param_name(name, 'Input parameter')
+    validate_param_name(name, 'Output parameter')
     return super(OutputFileParam, cls).__new__(cls, name, docker_path,
                                                remote_uri, recursive)
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -53,7 +53,18 @@ done
 # For each pattern, generate a list of matching tests and run them
 declare -a TEST_LIST
 for TEST_TYPE in "${TESTS[@]}"; do
-  TEST_LIST=($(eval ls "${SCRIPT_DIR}/${TEST_TYPE}" || true))
+
+  if [[ "${TEST_TYPE}" == "unit_*.py" ]]; then
+    # for unit tests, also include the Python unit tests
+    if python -m unittest discover -s test/unit/; then
+      echo "Test test/unit/*: PASSED"
+    else
+      echo "Test test/unit/*: FAILED"
+      exit 1
+    fi
+  fi
+
+  TEST_LIST=($(eval ls "${SCRIPT_DIR}/${TEST_TYPE}" 2>/dev/null || true))
 
   if [[ -z "${TEST_LIST:-}" ]]; then
     continue

--- a/test/setup_and_run_tests.sh
+++ b/test/setup_and_run_tests.sh
@@ -3,14 +3,14 @@
 set -o errexit
 set -o nounset
 
-if [[ "$#" -gt 0 ]]; then
+if [[ "${1:-}" == "--help" ]]; then
   cat <<EOF
 USAGE:
-  $0
+  $0 [unit|e2e]
 
 Sets up a virtualenv named dsub_libs in the current working directory and runs
-the unit tests. If the virtualenv already exists, will install the dependent
-dsub libraries into it.
+the (fast) unit and/or (slow) e2e tests (runs both if unspecified).
+If the virtualenv already exists, will install the dependent dsub libraries into it.
 EOF
   exit 0
 fi
@@ -31,10 +31,10 @@ echo ""
 echo "Starting tests."
 echo ""
 
-# TODO: once this works reliably, add the e2e tests
+echo "Your test bucket is: gs://${USER}-dsub-test"
 
-if ! python -m unittest discover -s test/unit/; then
-  echo "A test in test/unit/ failed."
+if ! test/run_tests.sh "$@"; then
+  echo "test/run_tests $* failed."
   exit 1
 fi
 

--- a/test/test_setup_e2e.sh
+++ b/test/test_setup_e2e.sh
@@ -43,7 +43,7 @@ if [[ -n "${YOUR_PROJECT:-}" ]]; then
   PROJECT_ID="${YOUR_PROJECT}"
 else
   echo "Checking configured gcloud project"
-  PROJECT_ID="$(gcloud config list core/project --format='value(core.project)')"
+  PROJECT_ID="$(gcloud config get-value project 2>/dev/null)"
 fi
 
 if [[ -z "${PROJECT_ID}" ]]; then
@@ -65,8 +65,12 @@ echo "  Bucket detected as: ${DSUB_BUCKET}"
 
 echo "  Checking if bucket exists"
 if ! gsutil ls "gs://${DSUB_BUCKET}" 2>/dev/null; then
-  2>&1 echo "Bucket does not exist: ${DSUB_BUCKET}"
+  2>&1 echo "Bucket does not exist (or we have no access): ${DSUB_BUCKET}"
   2>&1 echo "Create the bucket with \"gsutil mb\"."
+  2>&1 echo "Current gcloud settings:"
+  2>&1 echo "  account: $(gcloud config get-value account 2>/dev/null)"
+  2>&1 echo "  project: $(gcloud config get-value project 2>/dev/null)"
+  2>&1 echo "  pass_credentials_to_gsutil: $(gcloud config get-value pass_credentials_to_gsutil 2>/dev/null)"
   exit 1
 fi
 

--- a/test/unit/test_dsub_util.py
+++ b/test/unit/test_dsub_util.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for google3.lifescience.bioquery.tools.gsub_unittest.dsub_util."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import unittest
+from lib import dsub_util
+
+
+class TestDsubUtil(unittest.TestCase):
+
+  def testLoadFile(self):
+    tsv_file = 'test/testdata/params_table.tsv'
+    self.assertTrue(dsub_util.load_file(tsv_file))
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Key updates:
  * Add a new flag "--format" which supports "json|text|yaml". This allows the user to explicitly control the output format.
  * Make "--full" emit YAML by default (instead of text. User can still use "--full --format text")
  * Make "--full" emit the full contents of fields (rather than truncated).
  * For json and yaml output, use internal field ids (such as "job-id" instead of "Job ID").