### PR TITLE
Remove setup.py restriction on oauth2client version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'oauth2client==1.5.2', 'google-api-python-client', 'python-dateutil',
+        'oauth2client', 'google-api-python-client', 'python-dateutil',
         'pytz', 'pyyaml', 'tabulate'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'oauth2client', 'google-api-python-client', 'python-dateutil',
-        'pytz', 'pyyaml', 'tabulate'
+        'oauth2client', 'google-api-python-client', 'python-dateutil', 'pytz',
+        'pyyaml', 'tabulate'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
The oauth2client version required by setup.py is 1.5.2 which is far behind the current 4.1.1 version.  This means that users encounter long fixed issues like default application credentials not working out of the box in Cloud Shell.