### PR TITLE
Create travis config for dsub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "python setup.py install"
+# command to run tests
+script: "test/run_tests.sh pythonunit"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This is not an official Google product.
 
 # dsub: simple batch jobs with Docker
+[![Build Status](https://travis-ci.org/e4p/dsub.svg?branch=testtravis)](https://travis-ci.org/e4p/dsub)
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/googlegenomics/dsub/blob/master/LICENSE)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 This is not an official Google product.
 
 # dsub: simple batch jobs with Docker
-[![Build Status](https://travis-ci.org/e4p/dsub.svg?branch=testtravis)](https://travis-ci.org/e4p/dsub)
-[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/googlegenomics/dsub/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://github.com/googlegenomics/dsub/blob/master/LICENSE)
 
 ## Overview
 

--- a/test/unit/test_param_util.py
+++ b/test/unit/test_param_util.py
@@ -20,12 +20,6 @@ from dsub.lib import param_util
 import parameterized
 
 
-class ParamUtilTravisFailure(unittest.TestCase):
-
-  def testEnvParam(self):
-    self.assertEqual('Yes', 'No')
-
-
 class ParamUtilTest(unittest.TestCase):
 
   def testEnvParam(self):

--- a/test/unit/test_param_util.py
+++ b/test/unit/test_param_util.py
@@ -20,6 +20,12 @@ from dsub.lib import param_util
 import parameterized
 
 
+class ParamUtilTravisFailure(unittest.TestCase):
+
+  def testEnvParam(self):
+    self.assertEqual('Yes', 'No')
+
+
 class ParamUtilTest(unittest.TestCase):
 
   def testEnvParam(self):


### PR DESCRIPTION
After pushing this config to the [development branch](https://github.com/e4p/dsub/tree/testtravis), I tested that Travis can pass and fail a dsub build by sending several test commits to the development branch. The first commit added a test failure and Travis responded by failing the build. The last commit removed this test failure and Travis passed the build. I should highlight that Travis only runs Python unit tests for now. This is useful as a sanity check but obviously we should continue to run end-to-end tests for all pull requests.

See build history here: https://travis-ci.org/e4p/dsub

I've also added a license badge to start the (hopefully small) collection of badges. After several builds on the main branch we should add the Travis badge to our readme.

Finally, I've left the full commit history in this pull so you can see what caused test failures, but this should be squashed once it is accepted since two of the commits negate each other's changes.