### PR TITLE
Add "--user" flag to dsub. Add simpler setup via "make".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VIRTUALENV := dsub_env
+
+PYTHON_VERSION := $(shell python --version 2>&1)
+PYTHON_LIST := $(wordlist 2,4,$(subst ., ,$(PYTHON_VERSION)))
+PYTHON_MAJOR_VERSION := $(word 1,${PYTHON_LIST})
+PYTHON_MINOR_VERSION := $(word 2,${PYTHON_LIST})
+
+PIP_VERSION := $(shell pip --version 2>/dev/null)
+PIP_LIST := $(wordlist 2,4,$(subst ., ,$(PIP_VERSION)))
+PIP_MAJOR_VERSION := $(word 1, ${PIP_LIST})
+
+all: checkversions
+
+install: checkversions virtualenv
+
+checkversions:
+ifndef PYTHON_VERSION
+	$(error python executable not found; either update the path or install Python)
+endif
+ifneq "$(PYTHON_MAJOR_VERSION).$(PYTHON_MINOR_VERSION)" "2.7"
+	$(error Bad python version $(PYTHON_LIST); install 2.7.x)
+endif
+ifndef PIP_VERSION
+	$(error pip executable not found; either update the path or install pip)
+endif
+ifeq ($(PIP_MAJOR_VERSION),$(filter $(PIP_MAJOR_VERSION),"1" "2" "3" "4" "5" "6"))
+	$(error Bad pip version $(PIP_LIST); install >= 7.0.0)
+endif
+	@echo All prechecks pass. Ready to 'make install'.
+
+virtualenv:
+	mkdir -p install
+	pip install --upgrade virtualenv
+	virtualenv install/$(VIRTUALENV)
+	source install/$(VIRTUALENV)/bin/activate && \
+		python setup.py install
+	@echo Installed. You can now run the programs in bin/.
+
+clean:
+	rm -rf install

--- a/bin/ddel
+++ b/bin/ddel
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,17 @@
 set -o errexit
 set -o nounset
 
-readonly SCRIPT_DIR="$(dirname "${0}")"
-readonly DSUB_DIR="${SCRIPT_DIR}/.."
+readonly VIRTUALENV="dsub_env"
+readonly INSTALL_DIR="$(dirname "${0}")/../install"
+readonly COMMAND="${INSTALL_DIR}/${VIRTUALENV}/bin/$(basename "${0}")"
 
-cd "${DSUB_DIR}"
-
-# Handle the no-arg case to avoid "unbound variable" of "$@" on MacOS
-if [[ $# -eq 0 ]]; then
-  python -m dsub.commands.dstat
-else
-  python -m dsub.commands.dstat "${@}"
+if [[ ! -f "${COMMAND}" ]]; then
+  echo 'Command not installed! Run "make install" and try again.'
+  exit 1
 fi
+
+set +o nounset  # https://github.com/pypa/virtualenv/pull/922
+source "${INSTALL_DIR}/${VIRTUALENV}/bin/activate"
+set -o nounset
+
+exec "${COMMAND}" "${@}"

--- a/bin/dstat
+++ b/bin/dstat
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,17 @@
 set -o errexit
 set -o nounset
 
-readonly SCRIPT_DIR="$(dirname "${0}")"
-readonly DSUB_DIR="${SCRIPT_DIR}/.."
+readonly VIRTUALENV="dsub_env"
+readonly INSTALL_DIR="$(dirname "${0}")/../install"
+readonly COMMAND="${INSTALL_DIR}/${VIRTUALENV}/bin/$(basename "${0}")"
 
-cd "${DSUB_DIR}"
-
-# Handle the no-arg case to avoid "unbound variable" of "$@" on MacOS
-if [[ $# -eq 0 ]]; then
-  python -m dsub.commands.ddel
-else
-  python -m dsub.commands.ddel "${@}"
+if [[ ! -f "${COMMAND}" ]]; then
+  echo 'Command not installed! Run "make install" and try again.'
+  exit 1
 fi
+
+set +o nounset  # https://github.com/pypa/virtualenv/pull/922
+source "${INSTALL_DIR}/${VIRTUALENV}/bin/activate"
+set -o nounset
+
+exec "${COMMAND}" "${@}"

--- a/bin/dsub
+++ b/bin/dsub
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,17 @@
 set -o errexit
 set -o nounset
 
-readonly SCRIPT_DIR="$(dirname "${0}")"
-readonly DSUB_DIR="${SCRIPT_DIR}/.."
+readonly VIRTUALENV="dsub_env"
+readonly INSTALL_DIR="$(dirname "${0}")/../install"
+readonly COMMAND="${INSTALL_DIR}/${VIRTUALENV}/bin/$(basename "${0}")"
 
-cd "${DSUB_DIR}"
-
-# Handle the no-arg case to avoid "unbound variable" of "$@" on MacOS
-if [[ $# -eq 0 ]]; then
-  python -m dsub.commands.dsub
-else
-  python -m dsub.commands.dsub "${@}"
+if [[ ! -f "${COMMAND}" ]]; then
+  echo 'Command not installed! Run "make install" and try again.'
+  exit 1
 fi
+
+set +o nounset  # https://github.com/pypa/virtualenv/pull/922
+source "${INSTALL_DIR}/${VIRTUALENV}/bin/activate"
+set -o nounset
+
+exec "${COMMAND}" "${@}"

--- a/dsub/commands/ddel.py
+++ b/dsub/commands/ddel.py
@@ -60,7 +60,7 @@ def parse_arguments():
       '--users',
       '-u',
       nargs='*',
-      default=[dsub_util.get_default_user()],
+      default=[],
       help="""Deletes only those jobs which were submitted by the list of users.
           Use "*" to delete jobs of any user.""")
   return parser.parse_args()
@@ -84,13 +84,18 @@ def main():
   # Set up the Genomics Pipelines service interface
   provider = provider_base.get_provider(args)
 
+  # Make sure users were provided, or try to fill from OS user. This cannot
+  # be made into a default argument since some environments lack the ability
+  # to provide a username automatically.
+  user_list = args.users if args.users else [dsub_util.get_os_user()]
+
   # Let the user know which jobs we are going to look up
   with dsub_util.replace_print():
-    emit_search_criteria(args.users, args.jobs, args.tasks)
+    emit_search_criteria(user_list, args.jobs, args.tasks)
 
     # Delete the requested jobs
     deleted_tasks, error_messages = provider.delete_jobs(
-        args.users, args.jobs, args.tasks)
+        user_list, args.jobs, args.tasks)
 
     # Emit any errors canceling jobs
     for msg in error_messages:

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -224,10 +224,10 @@ def parse_arguments():
   parser.add_argument(
       '-j', '--jobs', nargs='*', help='A list of jobs on which to check status')
   parser.add_argument(
-      '-u',
       '--users',
+      '-u',
       nargs='*',
-      default=[dsub_util.get_default_user()],
+      default=[],
       help="""Lists only those jobs which were submitted by the list of users.
           Use "*" to list jobs of any user.""")
   parser.add_argument(
@@ -294,13 +294,18 @@ def main():
   # Set up the Genomics Pipelines service interface
   provider = provider_base.get_provider(args)
 
+  # Make sure users were provided, or try to fill from OS user. This cannot
+  # be made into a default argument since some environments lack the ability
+  # to provide a username automatically.
+  user_list = args.users if args.users else [dsub_util.get_os_user()]
+
   # Track if any jobs are running in the event --wait was requested.
   some_job_running = True
   while some_job_running:
 
     tasks = provider.lookup_job_tasks(
         args.status,
-        user_list=args.users,
+        user_list=user_list,
         job_list=args.jobs,
         max_jobs=args.limit)
 

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -309,6 +309,11 @@ def parse_arguments(prog, argv):
       action='store_true',
       help="""Enable new behavior for --input parameters that include wildcard
         patterns. This will become the default.""")
+  parser.add_argument(
+      '--user',
+      '-u',
+      default=None,
+      help='User submitting the dsub job, defaults to the current OS user.')
 
   # Add dsub job management arguments
   parser.add_argument(
@@ -423,9 +428,9 @@ def get_job_metadata(args, script, provider):
   Returns:
     A dictionary of job-specific metadata (such as job id, name, etc.)
   """
-
+  user_name = args.user or dsub_util.get_os_user()
   job_metadata = provider.prepare_job_metadata(script.name, args.name,
-                                               dsub_util.get_default_user())
+                                               user_name)
 
   job_metadata['script'] = script
 

--- a/dsub/lib/dsub_util.py
+++ b/dsub/lib/dsub_util.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Utility functions used by dsub, dstat, ddel."""
 
+from __future__ import print_function
+
 from contextlib import contextmanager
 import fnmatch
 import io
@@ -65,11 +67,11 @@ def replace_print(fileobj=sys.stderr):
 
 def print_error(msg):
   """Utility routine to emit messages to stderr."""
-  print >> sys.stderr, msg
+  print(msg, file=sys.stderr)
 
 
-def get_default_user():
-  """Returns the current user."""
+def get_os_user():
+  """Returns the current OS user, this may be different from the dsub user."""
   return pwd.getpwuid(os.getuid())[0]
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,18 @@
 File is based on this template: https://github.com/pypa/sampleproject
 """
 
-# To use a consistent encoding
-from codecs import open  # pylint: disable=redefined-builtin
-from os import path
+import unittest
 # Always prefer setuptools over distutils
 from setuptools import find_packages
 from setuptools import setup
 
-here = path.abspath(path.dirname(__file__))
 
-# Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-  long_description = f.read()
+def unittest_suite():
+  """Get test suite (Python unit tests only)."""
+  test_loader = unittest.TestLoader()
+  test_suite = test_loader.discover('test/unit', pattern='test_*.py')
+  return test_suite
+
 
 setup(
     name='dsub',
@@ -25,7 +25,6 @@ setup(
     version='0.0.0',
     description=('A command-line tool that makes it easy to submit and run'
                  ' batch scripts in the cloud'),
-    long_description=long_description,
 
     # The project's main homepage.
     url='https://github.com/googlegenomics/dsub',
@@ -88,6 +87,9 @@ setup(
         # dependencies for test code
         'parameterized',
     ],
+
+    # Define a test suite for Python unittests only.
+    test_suite='setup.unittest_suite',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/test/integration/e2e_local_files.local.sh
+++ b/test/integration/e2e_local_files.local.sh
@@ -24,8 +24,9 @@ set -o nounset
 #     - accept local inputs
 #     - write to a local output
 #     - save logs to a local directory
-#  * non-recursive and recursive I/O should work for the local
+#  * Non-recursive and recursive I/O should work for the local
 #    runner no differently than the remote runner.
+#  * Non-recursive and recursive I/O will create their output destinations.
 #
 # For a detailed description of what this test does, see e2e_io_recursive.sh.
 
@@ -57,11 +58,6 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Setting up pipeline input..."
   build_recursive_files "${INPUT_DEEP}" "${INPUT_SHALLOW}"
-
-  # Setup output
-  mkdir -p "${OUTPUT_DEEP}"
-  mkdir -p "${OUTPUT_SHALLOW}"
-  mkdir -p "${LOCAL_LOGGING}"
 
   echo "Launching pipeline..."
 

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for unit tests."""


### PR DESCRIPTION
Callers can now set the user-id label for the google provider with the `--user` flag.
Creation of a virtualenv can now be done with "make install".
Fixes race in local provider when canceling jobs which would mark the job as FAILED.
long_description removed from setup.py