### PR TITLE
BREAKING: Remove the --vars-include-wildcards flag.

### DIFF
--- a/docs/input_output.md
+++ b/docs/input_output.md
@@ -60,37 +60,13 @@ the `dsub` command-line:
 The object(s) at the Cloud Storage path will be copied and made available at
 the path `/mnt/data/input/gs/bucket/path`.
 
----
-Note: *The behavior of dsub for input file patterns is changing slightly.
-Please read this section carefully if you use input file patterns.*
-
----
-
-`dsub` originally made available to the Docker container the environment
-variable:
-
-```
-INPUT_FILES=/mnt/data/input/gs/bucket/path/
-```
-
-This is still true, *but will change*.
-
-The file pattern in this example (`*.bam`) is not available to the Docker
-container in the environment variable. The new behavior for `dsub` will be to
-set the environment variable value to:
+The Docker container will receive the environment variable:
 
 ```
 INPUT_FILES=/mnt/data/input/gs/bucket/path/*.bam
 ```
 
-To help users transition, there will be a short period in which both behaviors
-are available and the new behavior is explicitly enabled with a command-line
-flag. Once the new behavior is the default, the command-line flag will go away.
-
-During the transition period, to enable the new behavior, set
-`--vars-include-wildcards` on the `dsub` command-line.
-
-`dsub` script code will typically want to tokenize the environment variable
+You will likely want your script code to tokenize the environment variable
 into its constituent path and pattern components. To tokenize the `INPUT_FILES`
 variable, the following code:
 
@@ -106,16 +82,6 @@ INPUT_FILES_PATH=/mnt/data/input/gs/bucket/path
 INPUT_FILES_PATTERN=*.bam
 ```
 
----
-Note: If you are only interested in the path, the following notation will
-work with both the old and new behavior (it trims the final slash and anything
-that follows):
-
-```
-INPUT_FILES_PATH="${INPUT_FILES%/*}"
-```
----
-
 To process a list of files from a path + wildcard pattern in Bash, a typical
 coding pattern is to create an array and iterate over the array.
 
@@ -126,8 +92,8 @@ readonly INPUT_FILE_LIST=( $(ls "${INPUT_FILES_PATH}"/${INPUT_FILES_PATTERN}) )
 ```
 
 If you might have spaces in your file paths, then you need to take a bit more
-care. Here we create a list of files and force Bash to tokenize the list
-by newlines (instead of by whitespace):
+care. The following will create a list of files and force Bash to tokenize the
+list by newlines (instead of by whitespace):
 
 ```
 declare INPUT_FILE_LIST="$(ls -1 "${INPUT_FILES_PATH}"/${INPUT_FILES_PATTERN})"
@@ -136,7 +102,7 @@ readonly INPUT_FILE_LIST
 ```
 
 ---
-Note: in all cases, do not quote `${INPUT_FILES_PATTERN}` as that will
+Note: in both cases above, do not quote `${INPUT_FILES_PATTERN}` as that will
 suppress wildcard expansion.
 
 ---
@@ -150,7 +116,7 @@ for INPUT_FILE in "${INPUT_FILE_LIST[@]}"; do
   INPUT_FILE_NAME="$(basename "${INPUT_FILE}")"
 
   # If you further want to trim off the file extension, perhaps to construct
-  # a new output file name, then use bash suffix subsititution:
+  # a new output file name, then use Bash suffix subsititution:
   INPUT_FILE_ROOTNAME="${INPUT_FILE_NAME%.*}"
 
   # Do stuff with the INPUT_FILE environment variables you now have
@@ -223,7 +189,7 @@ Typically a job script will have the output file extensions hard-coded, but
 if needed it can be parsed from the environment variable. More commonly,
 the job script will need the output directory.
 
-To get the output directory and file extension in bash:
+To get the output directory and file extension in Bash:
 
 ```
 # This will set OUTPUT_DIR to "/mnt/data/output/gs/bucket/path"
@@ -232,7 +198,7 @@ OUTPUT_DIR="$(dirname "${OUTPUT_FILES}")"
 # This will set OUTPUT_FILE_PATTERN to "*.bam"
 OUTPUT_FILE_PATTERN="$(basename "${OUTPUT_FILES}")"
 
-# This will set OUTPUT_EXTENSION to "bam" using the bash prefix removal
+# This will set OUTPUT_EXTENSION to "bam" using the Bash prefix removal
 # operator "##", matching the longest pattern up to and including the period.
 OUTPUT_EXTENSION="${OUTPUT_FILE_PATTERN##*.}"
 ```

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -304,12 +304,6 @@ def parse_arguments(prog, argv):
           execution environment""",
       metavar='KEY=REMOTE_PATH')
   parser.add_argument(
-      '--vars-include-wildcards',
-      default=False,
-      action='store_true',
-      help="""Enable new behavior for --input parameters that include wildcard
-        patterns. This will become the default.""")
-  parser.add_argument(
       '--user',
       '-u',
       default=None,
@@ -433,10 +427,6 @@ def get_job_metadata(args, script, provider):
                                                user_name)
 
   job_metadata['script'] = script
-
-  # vars_include_wildcards is around just for a short time.
-  # Putting it in the metadata allows for touching less code.
-  job_metadata['vars_include_wildcards'] = args.vars_include_wildcards
 
   return job_metadata
 
@@ -609,27 +599,6 @@ def _job_outputs_are_present(job_data):
   return True
 
 
-def _check_wildcard_inputs(vars_include_wildcards, all_task_data):
-  if vars_include_wildcards:
-    return
-
-  inputs = all_task_data[0]['inputs']
-  inputs_with_wildcards = [
-      var for var in inputs
-      if not var.recursive and '*' in os.path.basename(var.docker_path)
-  ]
-  if inputs_with_wildcards:
-    print 'WARNING: The behavior of docker environment variables for input'
-    print '         parameters with wildcard (*) values is changing.'
-    print '         Set --vars-include-wildcards to enable the new behavior so'
-    print '         you can change your code before it becomes the default.'
-    print '         The following input parameters include wildcards:'
-    print '\n'.join([
-        '           {0}={1}'.format(var.name, var.uri)
-        for var in inputs_with_wildcards
-    ])
-
-
 def dsub_main(prog, argv):
   # Parse args and validate
   args = parse_arguments(prog, argv)
@@ -703,8 +672,6 @@ def run_main(args):
     all_task_data = param_util.args_to_job_data(
         args.env, args.label, args.input, args.input_recursive, args.output,
         args.output_recursive, input_file_param_util, output_file_param_util)
-
-  _check_wildcard_inputs(args.vars_include_wildcards, all_task_data)
 
   if not args.dry_run:
     print 'Job: %s' % job_metadata['job-id']

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -357,8 +357,7 @@ class _Pipelines(object):
     }
 
   @classmethod
-  def _build_pipeline_docker_command(cls, script_name, inputs, outputs,
-                                     vars_include_wildcards):
+  def _build_pipeline_docker_command(cls, script_name, inputs, outputs):
     """Return a multi-line string containg the full pipeline docker command."""
 
     # We upload the user script as an environment argument
@@ -411,12 +410,11 @@ class _Pipelines(object):
         var for var in inputs
         if not var.recursive and '*' in os.path.basename(var.docker_path)
     ]
-    if vars_include_wildcards:
-      export_inputs_with_wildcards = '\n'.join([
-          'export {0}="{1}/{2}"'.format(var.name, DATA_MOUNT_POINT,
-                                        var.docker_path)
-          for var in inputs_with_wildcards
-      ])
+    export_inputs_with_wildcards = '\n'.join([
+        'export {0}="{1}/{2}"'.format(var.name, DATA_MOUNT_POINT,
+                                      var.docker_path)
+        for var in inputs_with_wildcards
+    ])
 
     return DOCKER_COMMAND.format(
         mk_runtime_dirs=MK_RUNTIME_DIRS_COMMAND,
@@ -434,8 +432,7 @@ class _Pipelines(object):
   @classmethod
   def build_pipeline(cls, project, min_cores, min_ram, disk_size,
                      boot_disk_size, preemptible, image, zones, script_name,
-                     envs, inputs, outputs, pipeline_name,
-                     vars_include_wildcards):
+                     envs, inputs, outputs, pipeline_name):
     """Builds a pipeline configuration for execution.
 
     Args:
@@ -455,17 +452,14 @@ class _Pipelines(object):
       outputs: list of FileParam objects specifying output variables to set
         within each job.
       pipeline_name: string name of pipeline.
-      vars_include_wildcards: boolean flag indicating whether environment
-        variables for input parameters should include the wildcard (file)
-        portion of the path.
 
     Returns:
       A nested dictionary with one entry under the key emphemeralPipeline
       containing the pipeline configuration.
     """
     # Format the docker command
-    docker_command = cls._build_pipeline_docker_command(
-        script_name, inputs, outputs, vars_include_wildcards)
+    docker_command = cls._build_pipeline_docker_command(script_name, inputs,
+                                                        outputs)
 
     # Pipelines inputParameters can be both simple name/value pairs which get
     # set as environment variables, as well as input file paths which the
@@ -1072,8 +1066,7 @@ class GoogleJobProvider(base.JobProvider):
         envs=job_data['envs'],
         inputs=job_data['inputs'],
         outputs=job_data['outputs'],
-        pipeline_name=job_metadata['pipeline-name'],
-        vars_include_wildcards=job_metadata['vars_include_wildcards'])
+        pipeline_name=job_metadata['pipeline-name'])
 
     # Build the pipelineArgs for this job.
     pipeline.update(

--- a/test/integration/e2e_input_wildcards.sh
+++ b/test/integration/e2e_input_wildcards.sh
@@ -75,7 +75,6 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
     --script "${SCRIPT_DIR}/script_input_wildcards.sh" \
     --input INPUT_BASIC="${GS_INPUT_BASIC}" \
     --input INPUT_WITH_SPACE="${GS_INPUT_WITH_SPACE}" \
-    --vars-include-wildcards \
     --wait
 
 fi

--- a/test/unit/test_dsub_util.py
+++ b/test/unit/test_dsub_util.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for google3.lifescience.bioquery.tools.gsub_unittest.dsub_util."""
+"""Tests for dsub.lib.dsub_util."""
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
This is a breaking change that resolves
   https://github.com/googlegenomics/dsub/issues/43.

The old behavior (environment variable values for wildcard inputs are directory paths) is no longer available.

The new non-lossy behavior (environment variable values include the wildcards) is the only behavior.

Instructions for processing such values are in docs/input_output.md.
