### PR TITLE
dstat: Add support for restricting job lookups by date (--age).

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,6 +72,47 @@ To view results for all jobs associated with your user id:
 dstat --project my-project --status "*"
 ```
 
+### Check all of my jobs since <some time>
+
+To view results for jobs associated with your user id, since some point in time,
+use the `--age` flag.
+
+For example, the following command will return all jobs started in the last day:
+
+```
+./dstat --project my-project --status "*" --age 1d
+```
+
+The `--age` flags supports the following types of values:
+
+1. `<integer><unit>`
+2. `<integer>`
+
+The supported `unit` values are:
+
+* `s`: seconds
+* `m`: minutes
+* `h`: hours
+* `d`: days
+* `w`: weeks
+
+For example:
+
+* 60s (60 seconds)
+* 30m (30 minutes)
+* 12h (12 hours)
+* 3d (3 days)
+
+A bare integer value is interpreted as days since the epoch (January 1, 1970).
+
+This allows for the use of the `date` command to generate `--age` values.
+The [coreutils date command](https://www.gnu.org/software/coreutils/manual/html_node/Examples-of-date.html)
+supports even more flexible date strings:
+
+```
+./dstat ... --age "$(date --date="last friday" '+%s')"
+```
+
 ## Monitoring
 
 By default `dstat` will query job status and exit. However, you can use the

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -131,7 +131,8 @@ class JobProvider(object):
                        job_list=None,
                        job_name_list=None,
                        task_list=None,
-                       max_jobs=0):
+                       create_time=None,
+                       max_tasks=0):
     """Return a list of tasks based on the search criteria.
 
     If any of the filters are empty or "[*]", then no filtering is performed on
@@ -145,7 +146,8 @@ class JobProvider(object):
       job_list: a list of job ids to return.
       job_name_list: a list of job names to return.
       task_list: a list of specific tasks within the specified job(s) to return.
-      max_jobs: the maximum number of jobs to return or 0 for no limit.
+      create_time: a UTC value for earliest create time for a job.
+      max_tasks: the maximum number of job tasks to return or 0 for no limit.
 
     Returns:
       A list of provider-specific objects, each representing a submitted task.

--- a/dsub/providers/stub.py
+++ b/dsub/providers/stub.py
@@ -66,7 +66,8 @@ class StubJobProvider(base.JobProvider):
                        user_list='*',
                        job_list='*',
                        task_list='*',
-                       max_jobs=0):
+                       create_time=None,
+                       max_tasks=0):
     """Return a list of operations based on the input criteria.
 
     If any of the filters are empty or "[*]", then no filtering is performed on
@@ -78,7 +79,8 @@ class StubJobProvider(base.JobProvider):
       user_list: a list of ids for the user(s) who launched the job.
       job_list: a list of job ids to return.
       task_list: a list of specific tasks within the specified job(s) to return.
-      max_jobs: the maximum number of jobs to return or 0 for no limit.
+      create_time: a UTC value for earliest create time for a job.
+      max_tasks: the maximum number of job tasks to return or 0 for no limit.
 
     Returns:
       A list of Genomics API Operations objects.
@@ -92,8 +94,8 @@ class StubJobProvider(base.JobProvider):
             (job_list == '*' or x.get('job-id', None) in job_list) and
             (task_list == '*' or x.get('task-id', None) in task_list))
     ]
-    if max_jobs > 0:
-      operations = operations[:max_jobs]
+    if max_tasks > 0:
+      operations = operations[:max_tasks]
     return operations
 
   def get_task_field(self, task, field):

--- a/dsub/providers/test_fails.py
+++ b/dsub/providers/test_fails.py
@@ -47,8 +47,8 @@ class FailsJobProvider(base.JobProvider):
                        user_list=None,
                        job_list=None,
                        task_list=None,
-                       max_jobs=0):
-    del status_list, user_list, job_list, task_list, max_jobs  # never any jobs
+                       max_tasks=0):
+    del status_list, user_list, job_list, task_list, max_tasks  # never any jobs
     raise FailsException("fails provider made lookup_job_tasks fail")
 
   def get_task_status_message(self, task):

--- a/test/unit/test_dstat.py
+++ b/test/unit/test_dstat.py
@@ -1,0 +1,53 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for dsub.lib.dsub_util."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from datetime import datetime
+import unittest
+from dsub.commands import dstat as dstat_command
+import parameterized
+
+
+class TestDstat(unittest.TestCase):
+
+  fixed_time = datetime(2017, 1, 1)
+  fixed_time_utc = int(
+      (fixed_time - datetime.utcfromtimestamp(0)).total_seconds())
+
+  @parameterized.parameterized.expand([
+      ('simple_second', '1s', fixed_time_utc - 1),
+      ('simple_minute', '1m', fixed_time_utc - (1 * 60)),
+      ('simple_hour', '1h', fixed_time_utc - (1 * 60 * 60)),
+      ('simple_day', '1d', fixed_time_utc - (24 * 60 * 60)),
+      ('simple_week', '1w', fixed_time_utc - (7 * 24 * 60 * 60)),
+      ('simple_now', str(fixed_time_utc), fixed_time_utc),
+  ])
+  def test_compute_create_time(self, unused_name, age, expected):
+    result = dstat_command.compute_create_time(age, self.fixed_time)
+    self.assertEqual(expected, result)
+
+  @parameterized.parameterized.expand([
+      ('bad_units', '1second'),
+      ('overflow', '100000000w'),
+  ])
+  def test_compute_create_time_fail(self, unused_name, age):
+    with self.assertRaisesRegexp(ValueError, 'Unable to parse age string'):
+      _ = dstat_command.compute_create_time(age)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This can be used for semantic reasons (I'm only interested in jobs launched today).
This can be used for performance reasons (lookups can be much faster when restricted to recent jobs).