### PR TITLE
Throw exceptions for --wait/--after job failures; retry GCS file downloads

### DIFF
--- a/dsub/lib/dsub_errors.py
+++ b/dsub/lib/dsub_errors.py
@@ -1,0 +1,31 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Error classes for dsub specific operations."""
+
+
+class JobError(Exception):
+  """Exception containing error information of one or more jobs."""
+
+  def __init__(self, message, error_list):
+    super(JobError, self).__init__(message)
+    self.message = message
+    self.error_list = error_list
+
+
+class PredecessorJobFailureError(JobError):
+  pass
+
+
+class JobExecutionError(JobError):
+  pass

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'python-dateutil',
         'pytz',
         'pyyaml',
+        'retrying',
         'tabulate',
 
         # dependencies for test code

--- a/test/integration/e2e_after.py
+++ b/test/integration/e2e_after.py
@@ -1,0 +1,104 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test calling dsub from python.
+
+This test is a copy of the e2e_after.sh test with additional checks
+on the objects returned by dsub.call().
+"""
+
+import os
+import sys
+
+from dsub.lib import dsub_errors
+
+import test_setup_e2e as test
+import test_util
+
+TEST_FILE_PATH_1 = test.OUTPUTS + '/testfile1.txt'
+TEST_FILE_PATH_2 = test.OUTPUTS + '/testfile2.txt'
+
+if not os.environ.get('CHECK_RESULTS_ONLY'):
+  print 'Launching pipeline...'
+
+  # (1) Launch a simple job that should succeed after a short wait
+  # pyformat: disable
+  launched_job = test.run_dsub([
+      '--command', 'sleep 5s && echo "hello world" > "${OUT}"',
+      '--output', 'OUT=%s' % TEST_FILE_PATH_1])
+  # pyformat: enable
+
+  # (2) Wait for the previous job and then launch a new one that blocks
+  # until exit
+  # pyformat: disable
+  next_job = test.run_dsub([
+      '--after', launched_job['job-id'],
+      '--input', 'IN=%s' % TEST_FILE_PATH_1,
+      '--output', 'OUT=%s' % TEST_FILE_PATH_2,
+      '--wait',
+      '--command', 'cat "${IN}" > "${OUT}"'])
+  # pyformat: enable
+
+  # (3) Launch a job to test command execution failure
+  try:
+    # pyformat: disable
+    bad_job_wait = test.run_dsub([
+        '--command', 'exit 1',
+        '--wait'])
+    # pyformat: enable
+
+    print >> sys.stderr, 'Expected to throw dsub_errors.JobExecutionError'
+    sys.exit(1)
+  except dsub_errors.JobExecutionError as e:
+    if len(e.error_list) != 1:
+      print >> sys.stderr, 'Expected 1 error during wait, got: %s' % (
+          e.error_list)
+      sys.exit(1)
+
+  # (4) Launch a bad job to allow the next call to detect its failure
+  # pyformat: disable
+  bad_job_previous = test.run_dsub(['--command', 'sleep 5s && exit 1'])
+  # pyformat: enable
+
+  # (5) This call to dsub should fail before submit
+  try:
+    # pyformat: disable
+    job_after = test.run_dsub([
+        '--command', 'echo "does not matter"',
+        '--after', bad_job_previous['job-id']])
+    # pyformat: enable
+
+    print >> sys.stderr, 'Expected to throw a PredecessorJobFailureError'
+    sys.exit(1)
+  except dsub_errors.PredecessorJobFailureError as e:
+    if len(e.error_list) != 1:
+      print >> sys.stderr, 'Expected 1 error from previous job, got: %s' % (
+          e.error_list)
+      sys.exit(1)
+
+print
+print 'Checking output...'
+
+RESULT = test_util.gsutil_cat(TEST_FILE_PATH_2)
+if 'hello world' not in RESULT:
+  print 'Output file does not match expected'
+  sys.exit(1)
+
+print
+print 'Output file matches expected:'
+print '*****************************'
+print RESULT
+print '*****************************'
+
+print 'SUCCESS'

--- a/test/integration/e2e_after.sh
+++ b/test/integration/e2e_after.sh
@@ -24,42 +24,66 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 # Do standard test setup
 source "${SCRIPT_DIR}/test_setup_e2e.sh"
 
-TGT_1="${OUTPUTS}/testfile_1.txt"
-TGT_2="${OUTPUTS}/testfile_2.txt"
+TEST_FILE_PATH_1="${OUTPUTS}/testfile_1.txt"
+TEST_FILE_PATH_2="${OUTPUTS}/testfile_2.txt"
 
 
 if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Launching pipeline..."
 
+  # (1) Launch a simple job that should succeed after a short wait
   JOBID=$(run_dsub \
-    --image 'ubuntu' \
-    --command 'sleep 5s; echo hi > $OUT' \
-    --output OUT="${TGT_1}")
+    --command 'sleep 5s && echo "hello world" > "${OUT}"' \
+    --output OUT="${TEST_FILE_PATH_1}")
 
+  # (2) Wait for the previous job and then launch a new one that blocks
+  # until exit
   run_dsub \
-    --image 'ubuntu' \
-    --command 'cat $IN > $OUT' \
-    --input  IN="${TGT_1}" \
-    --output OUT="${TGT_2}" \
     --after "${JOBID}" \
+    --command 'cat "${IN}" > "${OUT}"' \
+    --input IN="${TEST_FILE_PATH_1}" \
+    --output OUT="${TEST_FILE_PATH_2}" \
     --wait
+
+  # (3) Launch a job to test command execution failure
+  if run_dsub \
+      --command 'exit 1' \
+      --wait; then
+    echo "Expected dsub to exit with error."
+    exit 1
+  fi
+
+  # (4) Launch a bad job to allow the next call to detect its failure
+  BAD_JOB_PREVIOUS=$(run_dsub \
+    --command 'sleep 5s && exit 1')
+
+  # (5) This call to dsub should fail before submit
+  if run_dsub \
+      --command 'echo "does not matter"' \
+      --after "${BAD_JOB_PREVIOUS}" \
+      --wait; then
+    echo "Expected dsub to exit with error."
+    exit 1
+  fi
 
 fi
 
 echo
 echo "Checking output..."
 
-readonly RESULT="$(gsutil cat "${TGT_2}")"
-if [[ "${RESULT}" != "hi" ]]; then
+readonly RESULT="$(gsutil cat "${TEST_FILE_PATH_2}")"
+if [[ "${RESULT}" != "hello world" ]]; then
   echo "Output file does not match expected"
-  echo "Expected: hi"
+  echo "Expected: hello world"
   echo "Got: ${RESULT}"
   exit 1
 fi
 
 echo
-echo "Output file matches expected."
+echo "Output file matches expected:"
+echo "*****************************"
+echo "${RESULT}"
 echo "*****************************"
 
 echo "SUCCESS"


### PR DESCRIPTION
If dsub is waiting for a job to complete, the Python API will now
get an exception thrown instead of simple sys.exit(1) call.

_load_file_from_gcs now has retries.