### PR TITLE
Pull Request for Release v0.1.5

### DIFF
--- a/docs/job_control.md
+++ b/docs/job_control.md
@@ -131,3 +131,11 @@ When wildcards are used for `--output` parameters or `--output-recursive`
 parameters are used, there is no way for `dsub` to verify that *all* output is
 present. The best that `dsub` can do is to verify that *some* output was created
 for each such parameter.
+
+While it's allowed to specify `--output` and `--tasks` on the command line
+at the same time (for example if output has wildcards and each task writes
+a different file that matches the pattern), note that in this scenario
+`--skip` will dutifully skip all tasks if any output matching the pattern is
+present. In practice this means that it's generally unwise to use all three
+of `--output`, `--tasks`, and `--skip` on the command line. Instead, specify
+a different output for each task, in the tasks file.

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.4'
+DSUB_VERSION = '0.1.4.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.4.dev0'
+DSUB_VERSION = '0.1.5'

--- a/dsub/commands/ddel.py
+++ b/dsub/commands/ddel.py
@@ -129,7 +129,7 @@ def main():
         job_ids=set(args.jobs) if args.jobs else None,
         task_ids=set(args.tasks) if args.tasks else None,
         labels=labels,
-        create_time=create_time)
+        create_time_min=create_time)
     # Emit the count of deleted jobs.
     # Only emit anything about tasks if any of the jobs contains a task-id.
     deleted_jobs = dsub_util.tasks_to_job_ids(deleted_tasks)
@@ -153,7 +153,8 @@ def ddel_tasks(provider,
                job_ids=None,
                task_ids=None,
                labels=None,
-               create_time=None):
+               create_time_min=None,
+               create_time_max=None):
   """Kill jobs or job tasks.
 
   This function separates ddel logic from flag parsing and user output. Users
@@ -165,14 +166,17 @@ def ddel_tasks(provider,
     job_ids: a set of job ids to delete.
     task_ids: a set of task ids to delete.
     labels: a set of LabelParam, each must match the job(s) to be cancelled.
-    create_time: a UTC value for earliest create time for a task.
+    create_time_min: a timezone-aware datetime value for the earliest create
+                     time of a task, inclusive.
+    create_time_max: a timezone-aware datetime value for the most recent create
+                     time of a task, inclusive.
 
   Returns:
     list of job ids which were deleted.
   """
   # Delete the requested jobs
   deleted_tasks, error_messages = provider.delete_jobs(
-      user_ids, job_ids, task_ids, labels, create_time)
+      user_ids, job_ids, task_ids, labels, create_time_min, create_time_max)
 
   # Emit any errors canceling jobs
   for msg in error_messages:

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -340,7 +340,7 @@ def main():
   args = _parse_arguments()
 
   # Compute the age filter (if any)
-  create_time = param_util.age_to_create_time(args.age)
+  create_time_min = param_util.age_to_create_time(args.age)
 
   # Set up the output formatter
   if args.format == 'json':
@@ -379,7 +379,7 @@ def main():
       job_names=set(args.names) if args.names else None,
       task_ids=set(args.tasks) if args.tasks else None,
       labels=labels if labels else None,
-      create_time=create_time,
+      create_time_min=create_time_min,
       max_tasks=args.limit,
       full_output=args.full,
       poll_interval=poll_interval,
@@ -401,7 +401,8 @@ def dstat_job_producer(provider,
                        job_names=None,
                        task_ids=None,
                        labels=None,
-                       create_time=None,
+                       create_time_min=None,
+                       create_time_max=None,
                        max_tasks=0,
                        full_output=False,
                        poll_interval=0,
@@ -419,7 +420,10 @@ def dstat_job_producer(provider,
     job_names: a set of job-name strings eligible jobs may match.
     task_ids: a set of task-id strings eligible tasks may match.
     labels: set of LabelParam that all tasks must match.
-    create_time: a UTC value for earliest create time for a task.
+    create_time_min: a timezone-aware datetime value for the earliest create
+                     time of a task, inclusive.
+    create_time_max: a timezone-aware datetime value for the most recent create
+                     time of a task, inclusive.
     max_tasks: (int) maximum number of tasks to return per dstat job lookup.
     full_output: (bool) return all dsub fields.
     poll_interval: (int) wait time between poll events, dstat will poll jobs
@@ -444,7 +448,8 @@ def dstat_job_producer(provider,
         job_names=job_names,
         task_ids=task_ids,
         labels=labels,
-        create_time=create_time,
+        create_time_min=create_time_min,
+        create_time_max=create_time_max,
         max_tasks=max_tasks)
 
     some_job_running = False

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -447,7 +447,8 @@ def dstat_job_producer(provider,
         labels=labels,
         create_time_min=create_time_min,
         create_time_max=create_time_max,
-        max_tasks=max_tasks)
+        max_tasks=max_tasks,
+        page_size=max_tasks)
 
     some_job_running = False
 
@@ -480,7 +481,8 @@ def lookup_job_tasks(provider,
                      labels=None,
                      create_time_min=None,
                      create_time_max=None,
-                     max_tasks=0):
+                     max_tasks=0,
+                     page_size=0):
   """Generate formatted jobs individually, in order of create-time.
 
   Args:
@@ -496,6 +498,8 @@ def lookup_job_tasks(provider,
     create_time_max: a timezone-aware datetime value for the most recent create
                      time of a task, inclusive.
     max_tasks: (int) maximum number of tasks to return per dstat job lookup.
+    page_size: the page size to use for each query to the backend. May be
+               ignored by some provider implementations.
 
   Yields:
     Individual task dictionaries with associated metadata
@@ -509,7 +513,8 @@ def lookup_job_tasks(provider,
       labels=labels,
       create_time_min=create_time_min,
       create_time_max=create_time_max,
-      max_tasks=max_tasks)
+      max_tasks=max_tasks,
+      page_size=page_size)
 
   # Yield formatted tasks.
   for task in tasks_generator:

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -409,9 +409,6 @@ def dstat_job_producer(provider,
                        raw_format=False):
   """Generate jobs as lists of task dicts ready for formatting/output.
 
-  This function separates dstat logic from flag parsing and user output. Users
-  of dstat who intend to access the data programmatically should use this.
-
   Args:
     provider: an instantiated dsub provider.
     statuses: a set of status strings that eligible jobs may match.
@@ -472,6 +469,52 @@ def dstat_job_producer(provider,
       time.sleep(poll_interval)
     else:
       break
+
+
+def lookup_job_tasks(provider,
+                     statuses,
+                     user_ids=None,
+                     job_ids=None,
+                     job_names=None,
+                     task_ids=None,
+                     labels=None,
+                     create_time_min=None,
+                     create_time_max=None,
+                     max_tasks=0):
+  """Generate formatted jobs individually, in order of create-time.
+
+  Args:
+    provider: an instantiated dsub provider.
+    statuses: a set of status strings that eligible jobs may match.
+    user_ids: a set of user strings that eligible jobs may match.
+    job_ids: a set of job-id strings eligible jobs may match.
+    job_names: a set of job-name strings eligible jobs may match.
+    task_ids: a set of task-id strings eligible tasks may match.
+    labels: set of LabelParam that all tasks must match.
+    create_time_min: a timezone-aware datetime value for the earliest create
+                     time of a task, inclusive.
+    create_time_max: a timezone-aware datetime value for the most recent create
+                     time of a task, inclusive.
+    max_tasks: (int) maximum number of tasks to return per dstat job lookup.
+
+  Yields:
+    Individual task dictionaries with associated metadata
+  """
+  tasks_generator = provider.lookup_job_tasks(
+      statuses,
+      user_ids=user_ids,
+      job_ids=job_ids,
+      job_names=job_names,
+      task_ids=task_ids,
+      labels=labels,
+      create_time_min=create_time_min,
+      create_time_max=create_time_max,
+      max_tasks=max_tasks)
+
+  # Yield formatted tasks.
+  for task in tasks_generator:
+    yield _prepare_row(task, True)
+
 
 if __name__ == '__main__':
   main()

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -107,7 +107,13 @@ class JobProvider(object):
     raise NotImplementedError()
 
   @abstractmethod
-  def delete_jobs(self, user_ids, job_ids, task_ids, labels, create_time=None):
+  def delete_jobs(self,
+                  user_ids,
+                  job_ids,
+                  task_ids,
+                  labels,
+                  create_time_min=None,
+                  create_time_max=None):
     """Kills the operations associated with the specified job or job.task.
 
     Some providers may provide only a "cancel" operation, which terminates the
@@ -118,7 +124,10 @@ class JobProvider(object):
       job_ids: a set of job ids to delete.
       task_ids: a set of task ids to delete.
       labels: a set of LabelParam, each must match the job(s) to be cancelled.
-      create_time: a UTC value for earliest create time for a task.
+      create_time_min: a timezone-aware datetime value for the earliest create
+                       time of a task, inclusive.
+      create_time_max: a timezone-aware datetime value for the most recent
+                       create time of a task, inclusive.
 
     Returns:
       (list of tasks canceled,
@@ -136,7 +145,8 @@ class JobProvider(object):
                        job_names=None,
                        task_ids=None,
                        labels=None,
-                       create_time=None,
+                       create_time_min=None,
+                       create_time_max=None,
                        max_tasks=0):
     """Return a list of tasks based on the search criteria.
 
@@ -152,7 +162,10 @@ class JobProvider(object):
       job_names: a set of job names to return.
       task_ids: a set of specific tasks within the specified job(s) to return.
       labels: a list of LabelParam, each must match the job(s) returned.
-      create_time: a UTC value for earliest create time for a task.
+      create_time_min: a timezone-aware datetime value for the earliest create
+                       time of a task, inclusive.
+      create_time_max: a timezone-aware datetime value for the most recent
+                       create time of a task, inclusive.
       max_tasks: the maximum number of job tasks to return or 0 for no limit.
 
     Returns:

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -76,7 +76,8 @@ class JobProvider(object):
     raise NotImplementedError()
 
   @abstractmethod
-  def submit_job(self, job_resources, job_metadata, job_data, all_task_data):
+  def submit_job(self, job_resources, job_metadata, job_data, all_task_data,
+                 skip_if_output_present):
     """Submit the job to be executed.
 
     Args:
@@ -84,6 +85,8 @@ class JobProvider(object):
       job_metadata: job parameters such as job-id, user-id, script.
       job_data: job parameters included in each task.
       all_task_data: list of parameters to launch each job task.
+      skip_if_output_present: (boolean) if true, skip tasks whose output
+        is present (see --skip flag for more explanation).
 
     job_resources contains settings related to how many resources to give each
     task. Its fields include: min_cores, min_ram, disk_size, boot_disk_size,
@@ -98,6 +101,8 @@ class JobProvider(object):
     Returns:
       A dictionary containing the 'user-id', 'job-id', and 'task-id' list.
       For jobs that are not task array jobs, the task-id list should be empty.
+      If all tasks were skipped, then the job-id is dsub_lib.NO_JOB.
+
 
     Raises:
       ValueError: submit job may validate any of the parameters and raise

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -152,7 +152,8 @@ class JobProvider(object):
                        labels=None,
                        create_time_min=None,
                        create_time_max=None,
-                       max_tasks=0):
+                       max_tasks=0,
+                       page_size=0):
     """Return a list of tasks based on the search criteria.
 
     If any of the filters are empty or {'*'}, then no filtering is performed on
@@ -172,6 +173,8 @@ class JobProvider(object):
       create_time_max: a timezone-aware datetime value for the most recent
                        create time of a task, inclusive.
       max_tasks: the maximum number of job tasks to return or 0 for no limit.
+      page_size: the page size to use for each query to the backend. May be
+                 ignored by provider implementations.
 
     Returns:
       A list of Task objects.

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -1126,8 +1126,10 @@ class GoogleJobProvider(base.JobProvider):
     # create-time). A sorted list can then be built by stepping through this
     # iterator and adding tasks until none are left or we hit max_tasks.
 
+    now = datetime.now()
+
     def _desc_date_sort_key(t):
-      return datetime.now() - t.get_field('create-time').replace(tzinfo=None)
+      return now - t.get_field('create-time').replace(tzinfo=None)
 
     query_queue = sorting_util.SortedGeneratorIterator(key=_desc_date_sort_key)
     for status, job_id, job_name, user_id, task_id in itertools.product(

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -83,8 +83,7 @@ TMP_DIR = '%s/tmp' % DATA_MOUNT_POINT
 WORKING_DIR = '%s/workingdir' % DATA_MOUNT_POINT
 
 MK_RUNTIME_DIRS_COMMAND = '\n'.join(
-    'mkdir --mode=777 -p "%s" ' % dir
-    for dir in [SCRIPT_DIR, TMP_DIR, WORKING_DIR])
+    'mkdir -m 777 -p "%s" ' % dir for dir in [SCRIPT_DIR, TMP_DIR, WORKING_DIR])
 
 DOCKER_COMMAND = textwrap.dedent("""\
   set -o errexit
@@ -510,13 +509,15 @@ class _Pipelines(object):
 
     input_files = [
         cls._build_pipeline_input_file_param(var.name, var.docker_path)
-        for var in inputs if not var.recursive
+        for var in inputs
+        if not var.recursive
     ]
 
     # Outputs are an array of file parameters
     output_files = [
         cls._build_pipeline_file_param(var.name, var.docker_path)
-        for var in outputs if not var.recursive
+        for var in outputs
+        if not var.recursive
     ]
 
     # The ephemeralPipeline provides the template for the pipeline.

--- a/dsub/providers/stub.py
+++ b/dsub/providers/stub.py
@@ -28,7 +28,13 @@ class StubJobProvider(base.JobProvider):
   def submit_job(self, job_resources, job_metadata, job_data, all_job_data):
     pass
 
-  def delete_jobs(self, user_ids, job_ids, task_ids, labels, create_time=None):
+  def delete_jobs(self,
+                  user_ids,
+                  job_ids,
+                  task_ids,
+                  labels,
+                  create_time_min=None,
+                  create_time_max=None):
     pass
 
   # 2) Methods that manipulate the state of the fictional operations.
@@ -70,7 +76,8 @@ class StubJobProvider(base.JobProvider):
                        job_names=None,
                        task_ids=None,
                        labels=None,
-                       create_time=None,
+                       create_time_min=None,
+                       create_time_max=None,
                        max_tasks=0):
     """Return a list of operations. See base.py for additional detail."""
     statuses = None if statuses == {'*'} else statuses
@@ -79,7 +86,7 @@ class StubJobProvider(base.JobProvider):
     job_names = None if job_names == {'*'} else job_names
     task_ids = None if task_ids == {'*'} else task_ids
 
-    if labels or create_time:
+    if labels or create_time_min or create_time_max:
       raise NotImplementedError(
           'Lookup by labels and create_time not yet supported by stub.')
 

--- a/test/integration/e2e_io.sh
+++ b/test/integration/e2e_io.sh
@@ -42,9 +42,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Launching pipeline..."
 
-  io_setup::run_dsub
+  JOB_ID=$(io_setup::run_dsub)
 
 fi
 
-# Check output
+# Do validation
 io_setup::check_output
+io_setup::check_dstat "${JOB_ID}"

--- a/test/integration/e2e_io_gcs_tasks.sh
+++ b/test/integration/e2e_io_gcs_tasks.sh
@@ -42,6 +42,8 @@ source "${SCRIPT_DIR}/io_tasks_setup.sh"
 
 if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
+  io_tasks_setup::write_tasks_file
+
   # Copy the script to GCS to test loading the script remotely
   echo "Copying script to ${DSUB_PARAMS}"
   gsutil cp "${SCRIPT_DIR}/script_io_test.sh" "${DSUB_PARAMS}/"
@@ -52,14 +54,16 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Launching pipelines..."
 
-  io_tasks_setup::run_dsub \
-    "${DSUB_PARAMS}/script_io_test.sh" \
-    "${DSUB_PARAMS}/$(basename "${TASKS_FILE}")"
+  JOB_ID="$(
+    io_tasks_setup::run_dsub \
+      "${DSUB_PARAMS}/script_io_test.sh" \
+      "${DSUB_PARAMS}/$(basename "${TASKS_FILE}")")"
 
 fi
 
-# Check output
+# Do validation
 io_tasks_setup::check_output
+io_tasks_setup::check_dstat "${JOB_ID}"
 
 # Clean up what we uploaded after the test is done.
 gsutil rm "${DSUB_PARAMS}"/**

--- a/test/integration/e2e_io_tasks.sh
+++ b/test/integration/e2e_io_tasks.sh
@@ -40,14 +40,18 @@ source "${SCRIPT_DIR}/io_tasks_setup.sh"
 
 if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
+  io_tasks_setup::write_tasks_file
+
   echo "Launching pipelines..."
 
-  io_tasks_setup::run_dsub \
-    "${SCRIPT_DIR}/script_io_test.sh" \
-    "${TASKS_FILE}"
+  JOB_ID="$(
+    io_tasks_setup::run_dsub \
+      "${SCRIPT_DIR}/script_io_test.sh" \
+      "${TASKS_FILE}")"
 
 fi
 
-# Check output
+# Do validation
 io_tasks_setup::check_output
+io_tasks_setup::check_dstat "${JOB_ID}"
 

--- a/test/integration/e2e_non_root.sh
+++ b/test/integration/e2e_non_root.sh
@@ -82,7 +82,7 @@ EOF
 
   echo "Launching pipeline..."
 
-  JOB_ID=$(io_setup::run_dsub)
+  JOB_ID="$(io_setup::run_dsub)"
 
   if [[ "${DSUB_PROVIDER}" == "local" ]]; then
     # Cleanup is more challenging when the Docker user isn't root,
@@ -92,5 +92,6 @@ EOF
 
 fi
 
-# Check output
+# Do validation
 io_setup::check_output
+io_setup::check_dstat "${JOB_ID}"

--- a/test/integration/e2e_python_api.py
+++ b/test/integration/e2e_python_api.py
@@ -1,0 +1,197 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test calling dsub and dstat directly via the python interface."""
+
+import os
+import sys
+import time
+
+from dsub.commands import dstat
+from dsub.commands import dsub
+from dsub.lib import job_util
+from dsub.lib import param_util
+from dsub.lib import resources
+from dsub.providers import google
+from dsub.providers import local
+
+import test_setup
+import test_setup_e2e as test
+
+
+def get_dsub_provider():
+  if test.DSUB_PROVIDER == 'local':
+    return local.LocalJobProvider(resources)
+  elif test.DSUB_PROVIDER == 'google':
+    return google.GoogleJobProvider(False, False, test.PROJECT_ID)
+  else:
+    print >> sys.stderr, 'Invalid provider specified.'
+    sys.exit(1)
+
+
+def dsub_start_job(command,
+                   name=None,
+                   envs=None,
+                   labels=None,
+                   inputs=None,
+                   inputs_recursive=None,
+                   outputs=None,
+                   outputs_recursive=None,
+                   wait=False):
+
+  envs = envs or {}
+  labels = labels or {}
+  inputs = inputs or {}
+  inputs_recursive = inputs_recursive or {}
+  outputs = outputs or {}
+  outputs_recursive = outputs_recursive or {}
+
+  labels['test-token'] = test_setup.TEST_TOKEN
+
+  logging = param_util.build_logging_param(test.LOGGING)
+  job_resources = job_util.JobResources(
+      image='ubuntu', logging=logging, zones=['us-central1-*'])
+
+  env_data = {param_util.EnvParam(k, v) for (k, v) in envs.items()}
+  label_data = {param_util.LabelParam(k, v) for (k, v) in labels.items()}
+
+  input_file_param_util = param_util.InputFileParamUtil('input')
+  input_data = set()
+  for (recursive, items) in ((False, inputs.items()),
+                             (True, inputs_recursive.items())):
+    for (name, value) in items:
+      name = input_file_param_util.get_variable_name(name)
+      input_data.add(input_file_param_util.make_param(name, value, recursive))
+
+  output_file_param_util = param_util.OutputFileParamUtil('output')
+  output_data = set()
+  for (recursive, items) in ((False, outputs.items()),
+                             (True, outputs_recursive.items())):
+    for (name, value) in items:
+      name = output_file_param_util.get_variable_name(name)
+      output_data.add(output_file_param_util.make_param(name, value, recursive))
+
+  job_data = {
+      'envs': env_data,
+      'inputs': input_data,
+      'outputs': output_data,
+      'labels': label_data,
+  }
+  all_task_data = [{
+      'envs': env_data,
+      'labels': label_data,
+      'inputs': input_data,
+      'outputs': output_data,
+  }]
+
+  return dsub.run(
+      get_dsub_provider(),
+      job_resources,
+      job_data,
+      all_task_data,
+      name=name,
+      command=command,
+      wait=wait,
+      disable_warning=True)
+
+
+def dstat_get_jobs(statuses=None,
+                   job_ids=None,
+                   task_ids=None,
+                   labels=None,
+                   create_time_min=None,
+                   create_time_max=None):
+  statuses = statuses or {'*'}
+  labels = labels or {}
+  labels['test-token'] = test_setup.TEST_TOKEN
+  labels_set = {param_util.LabelParam(k, v) for (k, v) in labels.items()}
+
+  return dstat.dstat_job_producer(
+      provider=get_dsub_provider(),
+      statuses=statuses,
+      job_ids=job_ids,
+      task_ids=task_ids,
+      labels=labels_set,
+      create_time_min=create_time_min,
+      create_time_max=create_time_max,
+      full_output=True).next()
+
+
+def dstat_get_job_names(statuses=None,
+                        job_ids=None,
+                        task_ids=None,
+                        labels=None,
+                        create_time_min=None,
+                        create_time_max=None):
+  return [
+      j['job-name']
+      for j in dstat_get_jobs(statuses, job_ids, task_ids, labels,
+                              create_time_min, create_time_max)
+  ]
+
+
+def exit_with_message(message):
+  print message
+  sys.exit(1)
+
+
+if not os.environ.get('CHECK_RESULTS_ONLY'):
+  print 'Launching pipelines...'
+  job1 = dsub_start_job('echo FIRST', name='job1')
+  time.sleep(1)
+  job2 = dsub_start_job('echo SECOND', name='job2')
+  time.sleep(1)
+  job3 = dsub_start_job('echo THIRD', name='job3')
+
+  first_job = dstat_get_jobs(job_ids={job1['job-id']})[0]
+  second_job = dstat_get_jobs(job_ids={job2['job-id']})[0]
+  third_job = dstat_get_jobs(job_ids={job3['job-id']})[0]
+
+  first_ct = first_job['create-time']
+  second_ct = second_job['create-time']
+  third_ct = third_job['create-time']
+
+  if dstat_get_job_names(create_time_min=first_ct) != ['job3', 'job2', 'job1']:
+    exit_with_message('Failed to get all jobs by create_time_min.')
+  if dstat_get_job_names(create_time_min=second_ct) != ['job3', 'job2']:
+    exit_with_message('Failed to get second and third jobs by create_time_min.')
+  if dstat_get_job_names(create_time_min=third_ct) != ['job3']:
+    exit_with_message('Failed to get the third job by create_time_min')
+  if dstat_get_job_names(create_time_max=first_ct) != ['job1']:
+    exit_with_message('Failed to get the first job by create_time_max')
+  if dstat_get_job_names(create_time_max=second_ct) != ['job2', 'job1']:
+    exit_with_message(
+        'Failed to get the first and second jobs by create_time_max.')
+  if dstat_get_job_names(create_time_max=third_ct) != ['job3', 'job2', 'job1']:
+    exit_with_message('Failed to get the all jobs by create_time_max.')
+  if dstat_get_job_names(
+      create_time_min=first_ct, create_time_max=first_ct) != ['job1']:
+    exit_with_message('Failed to get the first job by create time range.')
+  if dstat_get_job_names(
+      create_time_min=second_ct, create_time_max=second_ct) != ['job2']:
+    exit_with_message('Failed to get the second job by create time range.')
+  if dstat_get_job_names(
+      create_time_min=third_ct, create_time_max=third_ct) != ['job3']:
+    exit_with_message('Failed to get the third job by create time range.')
+  if dstat_get_job_names(
+      create_time_min=first_ct, create_time_max=second_ct) != ['job2', 'job1']:
+    exit_with_message(
+        'Failed to get the first and second jobs by create time range.')
+  if dstat_get_job_names(
+      create_time_min=second_ct, create_time_max=third_ct) != ['job3', 'job2']:
+    exit_with_message(
+        'Failed to get the second and third jobs by create time range.')
+  if dstat_get_job_names(
+      create_time_min=first_ct,
+      create_time_max=third_ct) != ['job3', 'job2', 'job1']:
+    exit_with_message('Failed to get all jobs by create time range.')

--- a/test/integration/e2e_skip.sh
+++ b/test/integration/e2e_skip.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Basic end to end test, without --tasks file.
+#
+# This test is designed to verify that --skip works.
+
+readonly SCRIPT_DIR="$(dirname "${0}")"
+
+# Do standard test setup
+source "${SCRIPT_DIR}/test_setup_e2e.sh"
+
+TEST_FILE_PATH_1="${OUTPUTS}/testfile_1.txt"
+TEST_FILE_PATH_2="${OUTPUTS}/testfile_2.txt"
+
+echo "hello world" | gsutil cp - "${TEST_FILE_PATH_1}"
+
+if gsutil ls "${TEST_FILE_PATH_2}" &> /dev/null; then
+  echo "Unexpected: the output file '${TEST_FILE_PATH_1}' already exists."
+  exit 1
+fi
+
+if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
+
+  echo "1. non-task single job: skip (output present)"
+  JOB_ID="$(
+    run_dsub \
+      --output OUTPUT_PATH="${TEST_FILE_PATH_1}" \
+      --command 'echo "hello from the job" > "${OUTPUT_PATH}"' \
+      --skip \
+      --wait)"
+
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_1}")"
+  if [[ "${RESULT}" != "hello world" ]]; then
+    echo "Output file does not match expected (from step 4)"
+    echo "Expected: hello world"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+
+  echo "2. non-task single job: do not skip (output not present)"
+  JOB_ID="$(
+    run_dsub \
+      --output OUTPUT_PATH="${TEST_FILE_PATH_2}" \
+      --command 'echo "hello from the job" > "${OUTPUT_PATH}"' \
+      --skip \
+      --wait)"
+
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_2}")"
+  if [[ "${RESULT}" != "hello from the job" ]]; then
+    echo "Output file does not match expected (from step 2)"
+    echo "Expected: hello world"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+
+  echo "SUCCESS"
+
+fi

--- a/test/integration/e2e_skip_tasks.sh
+++ b/test/integration/e2e_skip_tasks.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Basic end to end test, driven by a --tasks file.
+#
+# This test is designed to verify that --skip works.
+
+readonly SCRIPT_DIR="$(dirname "${0}")"
+
+# Do standard test setup
+source "${SCRIPT_DIR}/test_setup_e2e.sh"
+
+TEST_FILE_PATH_1="${OUTPUTS}/testfile_1.txt"
+TEST_FILE_PATH_2="${OUTPUTS}/testfile_2.txt"
+TEST_FILE_PATH_3="${OUTPUTS}/testfile_3.txt"
+
+if gsutil ls "${TEST_FILE_PATH_1}" &> /dev/null; then
+  echo "Unexpected: the output file '${TEST_FILE_PATH_1}' already exists."
+  exit 1
+fi
+
+if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
+
+  mkdir -p "${TEST_TMP}"
+  # TASKS_FILE is defined for us in test_setup.sh)
+  util::write_tsv_file "${TASKS_FILE}" \
+"
+    --output OUTPUT_PATH
+    ${TEST_FILE_PATH_1}
+"
+
+  echo "1. Should execute, write its output."
+  JOB_ID="$(
+    run_dsub \
+      --tasks "${TASKS_FILE}" \
+      --command 'echo "hello world" > "${OUTPUT_PATH}"' \
+      --skip \
+      --wait)"
+
+  if ! gsutil ls "${TEST_FILE_PATH_1}" &> /dev/null; then
+    echo "Unexpected: the output file '${TEST_FILE_PATH_1}' was not created."
+    exit 1
+  fi
+
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_1}")"
+  if [[ "${RESULT}" != "hello world" ]]; then
+    echo "Output file does not match expected (from step 1)"
+    echo "Expected: hello world"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+
+  echo "2. Should skip because output already exists."
+  JOB_ID="$(
+    run_dsub \
+      --tasks "${TASKS_FILE}" \
+      --command 'echo "hello again, world" > "${OUTPUT_PATH}"' \
+      --skip \
+      --wait)"
+
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_1}")"
+  if [[ "${RESULT}" != "hello world" ]]; then
+    echo "Output file does not match expected (from step 2)"
+    echo "Expected: hello world"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+
+  # Create a TSV file with two tasks
+  util::write_tsv_file "${TASKS_FILE}" \
+"
+    --output OUTPUT_PATH\t--env ROW
+    ${TEST_FILE_PATH_1}\t1
+    ${TEST_FILE_PATH_2}\t2
+"
+
+  echo "3. One task should be skipped, the other run."
+  JOB_ID="$(
+    run_dsub \
+      --tasks "${TASKS_FILE}" \
+      --command 'echo "hello again from row ${ROW}" > "${OUTPUT_PATH}"' \
+      --skip \
+      --wait)"
+
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_1}")"
+  if [[ "${RESULT}" != "hello world" ]]; then
+    echo "Output file does not match expected (from step 3)"
+    echo "Expected: hello world"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+  RESULT="$(gsutil cat "${TEST_FILE_PATH_2}")"
+  if [[ "${RESULT}" != "hello again from row 2" ]]; then
+    echo "Output file does not match expected (from step 3)"
+    echo "Expected: hello again from row 2"
+    echo "Got: ${RESULT}"
+    exit 1
+  fi
+
+  echo "SUCCESS"
+
+fi

--- a/test/integration/io_tasks.tsv.tmpl
+++ b/test/integration/io_tasks.tsv.tmpl
@@ -1,4 +1,0 @@
---env TASK_ID	--input INPUT_PATH	--output OUTPUT_PATH
-TASK_1	gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot3_exon_targetted_GRCh37_bams/data/NA06986/alignment/NA06986.chromY.ILLUMINA.bwa.CEU.exon_targetted.20100311.bam	${OUTPUTS}/1/*.md5
-TASK_2	gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot3_exon_targetted_GRCh37_bams/data/NA06986/alignment/NA06986.chrom21.ILLUMINA.bwa.CEU.exon_targetted.20100311.bam	${OUTPUTS}/2/*.md5
-TASK_3	gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot3_exon_targetted_GRCh37_bams/data/NA06986/alignment/NA06986.chrom18.ILLUMINA.bwa.CEU.exon_targetted.20100311.bam	${OUTPUTS}/3/*.md5

--- a/test/integration/test_setup_e2e.py
+++ b/test/integration/test_setup_e2e.py
@@ -133,10 +133,11 @@ if not os.environ.get("CHECK_RESULTS_ONLY"):
 
 if TASKS_FILE:
   # For a task file test, set up the task file from its template
-  # This should really be a feature of dsub directly...
   print "Setting up task file %s" % TASKS_FILE
-  os.makedirs(os.path.dirname(TASKS_FILE))
-  test_util.expand_tsv_fields(_environ(), TASKS_FILE_TMPL, TASKS_FILE)
+  if not os.path.exists(os.path.dirname(TASKS_FILE)):
+    os.makedirs(os.path.dirname(TASKS_FILE))
+  if os.path.exists(TASKS_FILE_TMPL):
+    test_util.expand_tsv_fields(_environ(), TASKS_FILE_TMPL, TASKS_FILE)
 
 
 # Functions for launching dsub

--- a/test/integration/test_setup_e2e.py
+++ b/test/integration/test_setup_e2e.py
@@ -104,8 +104,6 @@ TEST_GCS_DOCKER_ROOT = "gs/%s/dsub/py/%s/%s" % (DSUB_BUCKET, DSUB_PROVIDER,
 
 if TASKS_FILE:
   # For task file tests, the logging path is a directory.
-  # Eventually each job should have its own sub-directory,
-  # and named logging files but we need to add dsub support for that.
   LOGGING = "%s/logging" % TEST_GCS_ROOT
 else:
   # For regular tests, the logging path is a named file.

--- a/test/integration/test_setup_e2e.sh
+++ b/test/integration/test_setup_e2e.sh
@@ -127,7 +127,9 @@ if [[ -n "${TASKS_FILE:-}" ]]; then
   # This should really be a feature of dsub directly...
   echo "Setting up task file ${TASKS_FILE}"
   mkdir -p "$(dirname "${TASKS_FILE}")"
-  cat "${TASKS_FILE_TMPL}" \
-    | util::expand_tsv_fields \
-    > "${TASKS_FILE}"
+  if [[ -e "${TASKS_FILE_TMPL}" ]]; then
+    cat "${TASKS_FILE_TMPL}" \
+      | util::expand_tsv_fields \
+      > "${TASKS_FILE}"
+  fi
 fi

--- a/test/integration/test_setup_e2e.sh
+++ b/test/integration/test_setup_e2e.sh
@@ -83,9 +83,7 @@ readonly TEST_LOCAL_DOCKER_ROOT="file${TEST_LOCAL_ROOT}"
 
 if [[ -n "${TASKS_FILE:-}" ]]; then
   # For task file tests, the logging path is a directory.
-  # Eventually each job should have its own sub-directory,
-  # and named logging files but we need to add dsub support for that.
-  readonly LOGGING="${TEST_GCS_ROOT}/${TEST_NAME}/logging"
+  readonly LOGGING="${TEST_GCS_ROOT}/logging"
 else
   # For regular tests, the logging path is a named file.
   readonly LOGGING="${TEST_GCS_ROOT}/logging/${TEST_NAME}.log"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -237,6 +237,16 @@ The optional argument picks between:
 - unit: run test/integration/unit_*
 - e2e: run test/integration/e2e_*
 - pythonunit: run test/unit/*
+
+For tests in integration/, you can set the DSUB_PROVIDER
+environment variable to test only a specific provider;
+otherwise all are tested.
+
+You can run these tests individually, like e.g.:
+
+$ export DSUB_PROVIDER=local
+$ test/integration/e2e_skip.sh
+
 EOF
   exit 0
 fi

--- a/test/unit/dsub_util_test.py
+++ b/test/unit/dsub_util_test.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import os
 import unittest
 from dsub.lib import dsub_util
 
@@ -23,7 +24,8 @@ from dsub.lib import dsub_util
 class TestDsubUtil(unittest.TestCase):
 
   def testLoadFile(self):
-    tsv_file = 'test/testdata/params_tasks.tsv'
+    testpath = os.path.dirname(__file__)
+    tsv_file = os.path.join(testpath, '../testdata/params_tasks.tsv')
     self.assertTrue(dsub_util.load_file(tsv_file))
 
 

--- a/test/unit/param_util_test.py
+++ b/test/unit/param_util_test.py
@@ -111,7 +111,8 @@ class ParamUtilTest(unittest.TestCase):
     self.assertTrue(job_params[2].recursive)
 
   def testTasksFileToJobData(self):
-    expected_tsv_file = 'test/testdata/params_tasks.tsv'
+    testpath = os.path.dirname(__file__)
+    expected_tsv_file = os.path.join(testpath, '../testdata/params_tasks.tsv')
     input_file_param_util = param_util.InputFileParamUtil('input')
     output_file_param_util = param_util.OutputFileParamUtil('output')
     all_job_data = param_util.tasks_file_to_job_data({

--- a/test/unit/param_util_test.py
+++ b/test/unit/param_util_test.py
@@ -24,6 +24,7 @@ import unittest
 from dsub.lib import job_util
 from dsub.lib import param_util
 import parameterized
+import pytz
 
 
 # Fixed values for age_to_create_time
@@ -135,12 +136,12 @@ class ParamUtilTest(unittest.TestCase):
                        output.docker_path)
 
   @parameterized.parameterized.expand([
-      ('simple_second', '1s', FIXED_TIME_UTC - 1),
-      ('simple_minute', '1m', FIXED_TIME_UTC - (1 * 60)),
-      ('simple_hour', '1h', FIXED_TIME_UTC - (1 * 60 * 60)),
-      ('simple_day', '1d', FIXED_TIME_UTC - (24 * 60 * 60)),
-      ('simple_week', '1w', FIXED_TIME_UTC - (7 * 24 * 60 * 60)),
-      ('simple_now', str(FIXED_TIME_UTC), FIXED_TIME_UTC),
+      ('simple_second', '1s', FIXED_TIME - datetime.timedelta(seconds=1)),
+      ('simple_minute', '1m', FIXED_TIME - datetime.timedelta(minutes=1)),
+      ('simple_hour', '1h', FIXED_TIME - datetime.timedelta(hours=1)),
+      ('simple_day', '1d', FIXED_TIME - datetime.timedelta(days=1)),
+      ('simple_week', '1w', FIXED_TIME - datetime.timedelta(weeks=1)),
+      ('simple_now', str(FIXED_TIME_UTC), FIXED_TIME.replace(tzinfo=pytz.utc)),
   ])
   def test_compute_create_time(self, unused_name, age, expected):
     del unused_name

--- a/test/unit/sorting_util_test.py
+++ b/test/unit/sorting_util_test.py
@@ -19,8 +19,11 @@ import datetime
 import parameterized
 
 
+now = datetime.datetime.now()
+
+
 def _desc_date_sort_key(task):
-  return datetime.datetime.now() - task['create-time'].replace(tzinfo=None)
+  return now - task['create-time'].replace(tzinfo=None)
 
 
 JOB_STREAM_MULTI_1 = [


### PR DESCRIPTION
### Release v0.1.5 Fixes:
- `mkdir`: simplified flags now work with toybox
    - Toybox is a permissively licensed alternative to busybox (a shell tool binary toolkit). Unlike coreutils and busybox, older versions of toybox only accept single letter flags.

- Add more tests of dstat output
- Fix incorrect logging path (${TEST_NAME}/${TEST_NAME}) in e2e shell script --tasks tests
- Fix rare edge case causing incorrect ordering of jobs returned from dstat
- Resolves #97: Allow specification of upper-bound for job create-time  …
- Resolves #96: Add zone-awareness to dates returned by LocalJobProvider
- Resolves #100: dstat python lookup_job_tasks takes and delete_jobs takes `created_after` and `created_before` datetime rather than UTC int
- Improve `run_tests.sh` help message
- Expose the job-task generator in dstat
- Allow use of `--skip` and `--tasks` flags
- Add page_size parameter to dstat.lookup_job_tasks and corresponding provider