### PR TITLE
PR for 0.1.7 release

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.7.dev0'
+DSUB_VERSION = '0.1.7'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.6'
+DSUB_VERSION = '0.1.7.dev0'

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -225,6 +225,8 @@ def _prepare_row(task, full):
       row_spec('outputs', True, {}),
       row_spec('envs', True, {}),
       row_spec('labels', True, {}),
+      row_spec('provider', True, None),
+      row_spec('provider-attributes', True, {}),
       row_spec('dsub-version', False, None),
   ]
   # pyformat: enable

--- a/dsub/lib/dsub_util.py
+++ b/dsub/lib/dsub_util.py
@@ -305,13 +305,15 @@ def simple_pattern_exists_in_gcs(file_pattern, credentials=None):
 
 
 def outputs_are_present(outputs):
-  """True if each output contains at least one file."""
+  """True if each output contains at least one file or no output specified."""
   # outputs are OutputFileParam (see param_util.py)
 
   # If outputs contain a pattern, then there is no way for `dsub` to verify
   # that *all* output is present. The best that `dsub` can do is to verify
   # that *some* output was created for each such parameter.
   for o in outputs:
+    if not o.value:
+      continue
     if o.recursive:
       if not folder_exists(o.value):
         return False

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -55,6 +55,8 @@ from __future__ import print_function
 import collections
 import datetime
 import re
+import string
+
 from . import dsub_util
 from dateutil.tz import tzlocal
 import pytz
@@ -166,6 +168,25 @@ class LoggingParam(
     file_provider (enum): Service or infrastructure hosting the file.
   """
   pass
+
+
+def convert_to_label_chars(s):
+  """Turn the specified name and value into a valid Google label."""
+
+  # We want the results to be user-friendly, not just functional.
+  # So we can't base-64 encode it.
+  #   * If upper-case: lower-case it
+  #   * If the char is not a standard letter or digit. make it a dash
+  accepted_characters = string.ascii_lowercase + string.digits + '-'
+
+  def label_char_transform(char):
+    if char in accepted_characters:
+      return char
+    if char in string.ascii_uppercase:
+      return char.lower()
+    return '-'
+
+  return ''.join(label_char_transform(c) for c in s)
 
 
 class LabelParam(collections.namedtuple('LabelParam', ['name', 'value'])):

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -64,6 +64,7 @@ import yaml
 
 DEFAULT_MIN_CORES = 1
 DEFAULT_MIN_RAM = 3.75
+DEFAULT_MACHINE_TYPE = 'n1-standard-1'
 DEFAULT_DISK_SIZE = 200
 DEFAULT_BOOT_DISK_SIZE = 10
 DEFAULT_PREEMPTIBLE = False
@@ -325,23 +326,25 @@ class OutputFileParam(FileParam):
 
 class Resources(
     collections.namedtuple('Resources', [
-        'min_cores', 'min_ram', 'disk_size', 'boot_disk_size', 'preemptible',
-        'image', 'logging', 'logging_path', 'zones', 'scopes', 'keep_alive',
-        'accelerator_type', 'accelerator_count'
+        'min_cores', 'min_ram', 'machine_type', 'disk_size', 'boot_disk_size',
+        'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
+        'scopes', 'keep_alive', 'accelerator_type', 'accelerator_count'
     ])):
   """Job resource parameters related to CPUs, memory, and disk.
 
   Attributes:
     min_cores (int): number of CPU cores
     min_ram (float): amount of memory (in GB)
+    machine_type (str): machine type (e.g. 'n1-standard-1', 'custom-1-4096')
     disk_size (int): size of the data disk (in GB)
     boot_disk_size (int): size of the boot disk (in GB)
     preemptible (bool): use a preemptible VM for the job
     image (str): Docker image name
     logging (param_util.LoggingParam): user-specified location for jobs logs
     logging_path (param_util.LoggingParam): resolved location for jobs logs
-    zones (str): location in which to run the job
-    scopes (list): OAuth2 scopes for the job
+    regions (List[str]): region list in which to run the job
+    zones (List[str]): zone list in which to run the job
+    scopes (List[str]): OAuth2 scopes for the job
     keep_alive (int): Seconds to keep VM alive on failure
     accelerator_type (string): Accelerator type (e.g. 'nvidia-tesla-k80').
     accelerator_count (int): Number of accelerators of the specified type to
@@ -352,21 +355,23 @@ class Resources(
   def __new__(cls,
               min_cores=None,
               min_ram=None,
+              machine_type=None,
               disk_size=None,
               boot_disk_size=None,
               preemptible=None,
               image=None,
               logging=None,
               logging_path=None,
+              regions=None,
               zones=None,
               scopes=None,
               keep_alive=None,
               accelerator_type=None,
               accelerator_count=0):
     return super(Resources, cls).__new__(
-        cls, min_cores, min_ram, disk_size, boot_disk_size, preemptible, image,
-        logging, logging_path, zones, scopes, keep_alive, accelerator_type,
-        accelerator_count)
+        cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
+        preemptible, image, logging, logging_path, regions, zones, scopes,
+        keep_alive, accelerator_type, accelerator_count)
 
 
 def ensure_job_params_are_complete(job_params):

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -174,7 +174,7 @@ class LabelParam(collections.namedtuple('LabelParam', ['name', 'value'])):
   Subclasses of LabelParam may flip the _allow_reserved_keys attribute in order
   to allow reserved label values to be used. The check against reserved keys
   ensures that providers can rely on the label system to track dsub-related
-  values without allowing users to accidentially overwrite the labels.
+  values without allowing users to accidentally overwrite the labels.
 
   Attributes:
     name (str): the label name.
@@ -562,7 +562,7 @@ class JobDescriptor(object):
   def to_yaml(self):
     """Return a YAML string representing the job and task data.
 
-    A provider's internal represesentation of a dsub task typically does not map
+    A provider's internal representation of a dsub task typically does not map
     1-1 to the dsub representation. For example, the Google Genomics Pipeline
     does not natively support "input-recursive" or "output-recursive", so the
     google provider cannot easily reconstruct the user inputs from the

--- a/dsub/lib/providers_util.py
+++ b/dsub/lib/providers_util.py
@@ -35,10 +35,10 @@ def build_recursive_localize_env(destination, inputs):
     corresponding to the inputs.
   """
   export_input_dirs = '\n'.join([
-      'export {0}={1}/{2}'.format(var.name,
-                                  destination.rstrip('/'),
-                                  var.docker_path.rstrip('/')) for var in inputs
-      if var.recursive
+      'export {0}={1}/{2}'.format(var.name, destination.rstrip('/'),
+                                  var.docker_path.rstrip('/'))
+      for var in inputs
+      if var.recursive and var.docker_path
   ])
   return export_input_dirs
 

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -27,7 +27,6 @@ import textwrap
 
 from . import base
 from . import google_base
-from .._dsub_version import DSUB_VERSION
 
 # TODO(b/68858502) Remove the use of relative imports throughout this library
 from ..lib import dsub_util
@@ -745,60 +744,8 @@ class GoogleJobProvider(base.JobProvider):
 
   def prepare_job_metadata(self, script, job_name, user_id, create_time):
     """Returns a dictionary of metadata fields for the job."""
-
-    # The name of the pipeline gets set into the ephemeralPipeline.name as-is.
-    # The default name of the pipeline is the script name
-    # The name of the job is derived from the job_name and gets set as a
-    # 'job-name' label (and so the value must be normalized).
-    if job_name:
-      pipeline_name = job_name
-      job_name_value = job_model.convert_to_label_chars(job_name)
-    else:
-      pipeline_name = os.path.basename(script)
-      job_name_value = job_model.convert_to_label_chars(
-          pipeline_name.split('.', 1)[0])
-
-    # The user-id will get set as a label
-    user_id = job_model.convert_to_label_chars(user_id)
-
-    # Now build the job-id. We want the job-id to be expressive while also
-    # having a low-likelihood of collisions.
-    #
-    # For expressiveness, we:
-    # * use the job name (truncated at 10 characters).
-    # * insert the user-id
-    # * add a datetime value
-    # To have a high likelihood of uniqueness, the datetime value is out to
-    # hundredths of a second.
-    #
-    # The full job-id is:
-    #   <job-name>--<user-id>--<timestamp>
-    job_id = '%s--%s--%s' % (job_name_value[:10], user_id,
-                             create_time.strftime('%y%m%d-%H%M%S-%f')[:16])
-
-    # Standard version is MAJOR.MINOR(.PATCH). This will convert the version
-    # string to "vMAJOR-MINOR(-PATCH)". Example; "0.1.0" -> "v0-1-0".
-    version = job_model.convert_to_label_chars('v%s' % DSUB_VERSION)
-    return {
-        'pipeline-name': pipeline_name,
-        'job-name': job_name_value,
-        'job-id': job_id,
-        'user-id': user_id,
-        'dsub-version': version,
-    }
-
-  def _build_pipeline_labels(self, job_metadata, task_metadata):
-    labels = {
-        google_base.Label(name, job_metadata[name])
-        for name in ['job-name', 'job-id', 'user-id', 'dsub-version']
-    }
-
-    if task_metadata.get('task-id') is not None:
-      labels.add(
-          google_base.Label('task-id',
-                            'task-%d' % task_metadata.get('task-id')))
-
-    return labels
+    return google_base.prepare_job_metadata(script, job_name, user_id,
+                                            create_time)
 
   def _build_pipeline_request(self, task_view):
     """Returns a Pipeline objects for the job."""
@@ -810,7 +757,7 @@ class GoogleJobProvider(base.JobProvider):
     task_resources = task_view.task_descriptors[0].task_resources
 
     script = task_view.job_metadata['script']
-    task_params['labels'] |= self._build_pipeline_labels(
+    task_params['labels'] |= google_base.build_pipeline_labels(
         job_metadata, task_metadata)
 
     # Build the ephemeralPipeline for this job.

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -23,15 +23,11 @@ import itertools
 import json
 import os
 import re
-import socket
-import string
-import sys
 import textwrap
-from . import base
-from .._dsub_version import DSUB_VERSION
 
-import apiclient.discovery
-import apiclient.errors
+from . import base
+from . import google_base
+from .._dsub_version import DSUB_VERSION
 
 # TODO(b/68858502) Remove the use of relative imports throughout this library
 from ..lib import dsub_util
@@ -39,10 +35,7 @@ from ..lib import job_model
 from ..lib import param_util
 from ..lib import providers_util
 from ..lib import sorting_util
-from oauth2client.client import GoogleCredentials
-from oauth2client.client import HttpAccessTokenRefreshError
 import pytz
-import retrying
 
 _PROVIDER_NAME = 'google'
 
@@ -160,15 +153,6 @@ INSTALL_CLOUD_SDK = textwrap.dedent("""\
   fi
 """)
 
-# Transient errors for the Google APIs should not cause them to fail.
-# There are a set of HTTP and socket errors which we automatically retry.
-#  429: too frequent polling
-#  50x: backend error
-TRANSIENT_HTTP_ERROR_CODES = set([429, 500, 503, 504])
-
-# Socket error 104 (connection reset) should also be retried
-TRANSIENT_SOCKET_ERROR_CODES = set([104])
-
 # When attempting to cancel an operation that is already completed
 # (succeeded, failed, or canceled), the response will include:
 # "error": {
@@ -177,178 +161,6 @@ TRANSIENT_SOCKET_ERROR_CODES = set([104])
 # }
 FAILED_PRECONDITION_CODE = 400
 FAILED_PRECONDITION_STATUS = 'FAILED_PRECONDITION'
-
-# List of Compute Engine zones, which enables simple wildcard expansion.
-# We could look this up dynamically, but new zones come online
-# infrequently enough, this is easy to keep up with.
-# Also - the Pipelines API may one day directly support zone wildcards.
-#
-# To refresh this list:
-#   gcloud compute zones list --format='value(name)' \
-#     | sort | awk '{ printf "    '\''%s'\'',\n", $1 }'
-_ZONES = [
-    'asia-east1-a',
-    'asia-east1-b',
-    'asia-east1-c',
-    'asia-northeast1-a',
-    'asia-northeast1-b',
-    'asia-northeast1-c',
-    'asia-south1-a',
-    'asia-south1-b',
-    'asia-south1-c',
-    'asia-southeast1-a',
-    'asia-southeast1-b',
-    'australia-southeast1-a',
-    'australia-southeast1-b',
-    'australia-southeast1-c',
-    'europe-west1-b',
-    'europe-west1-c',
-    'europe-west1-d',
-    'europe-west2-a',
-    'europe-west2-b',
-    'europe-west2-c',
-    'europe-west3-a',
-    'europe-west3-b',
-    'europe-west3-c',
-    'europe-west4-b',
-    'europe-west4-c',
-    'northamerica-northeast1-a',
-    'northamerica-northeast1-b',
-    'northamerica-northeast1-c',
-    'southamerica-east1-a',
-    'southamerica-east1-b',
-    'southamerica-east1-c',
-    'us-central1-a',
-    'us-central1-b',
-    'us-central1-c',
-    'us-central1-f',
-    'us-east1-b',
-    'us-east1-c',
-    'us-east1-d',
-    'us-east4-a',
-    'us-east4-b',
-    'us-east4-c',
-    'us-west1-a',
-    'us-west1-b',
-    'us-west1-c',
-]
-
-
-def _get_zones(input_list):
-  """Returns a list of zones based on any wildcard input.
-
-  This function is intended to provide an easy method for producing a list
-  of desired zones for a pipeline to run in.
-
-  The Pipelines API default zone list is "any zone". The problem with
-  "any zone" is that it can lead to incurring Cloud Storage egress charges
-  if the GCE zone selected is in a different region than the GCS bucket.
-  See https://cloud.google.com/storage/pricing#network-egress.
-
-  A user with a multi-region US bucket would want to pipelines to run in
-  a "us-*" zone.
-  A user with a regional bucket in US would want to restrict pipelines to
-  run in a zone in that region.
-
-  Rarely does the specific zone matter for a pipeline.
-
-  This function allows for a simple short-hand such as:
-     [ "us-*" ]
-     [ "us-central1-*" ]
-  These examples will expand out to the full list of US and us-central1 zones
-  respectively.
-
-  Args:
-    input_list: list of zone names/patterns
-
-  Returns:
-    A list of zones, with any wildcard zone specifications expanded.
-  """
-
-  output_list = []
-
-  for zone in input_list:
-    if zone.endswith('*'):
-      prefix = zone[:-1]
-      output_list.extend([z for z in _ZONES if z.startswith(prefix)])
-    else:
-      output_list.append(zone)
-
-  return output_list
-
-
-def _print_error(msg):
-  """Utility routine to emit messages to stderr."""
-  print >> sys.stderr, msg
-
-
-class _Label(job_model.LabelParam):
-  """Name/value label metadata for a pipeline.
-
-  Attributes:
-    name (str): the label name.
-    value (str): the label value (optional).
-  """
-  _allow_reserved_keys = True
-  __slots__ = ()
-
-  @staticmethod
-  def convert_to_label_chars(s):
-    """Turn the specified name and value into a valid Google label."""
-
-    # We want the results to be user-friendly, not just functional.
-    # So we can't base-64 encode it.
-    #   * If upper-case: lower-case it
-    #   * If the char is not a standard letter or digit. make it a dash
-    accepted_characters = string.ascii_lowercase + string.digits + '-'
-
-    def label_char_transform(char):
-      if char in accepted_characters:
-        return char
-      if char in string.ascii_uppercase:
-        return char.lower()
-      return '-'
-
-    return ''.join(label_char_transform(c) for c in s)
-
-
-def _retry_api_check(exception):
-  """Return True if we should retry. False otherwise.
-
-  Args:
-    exception: An exception to test for transience.
-
-  Returns:
-    True if we should retry. False otherwise.
-  """
-  _print_error('Exception %s: %s' % (type(exception).__name__, str(exception)))
-
-  if isinstance(exception, apiclient.errors.HttpError):
-    if exception.resp.status in TRANSIENT_HTTP_ERROR_CODES:
-      return True
-
-  if isinstance(exception, socket.error):
-    if exception.errno in TRANSIENT_SOCKET_ERROR_CODES:
-      return True
-
-  if isinstance(exception, HttpAccessTokenRefreshError):
-    return True
-
-  return False
-
-
-class _Api(object):
-
-  # Exponential backoff retrying API execution.
-  # Maximum 23 retries.  Wait 1, 2, 4 ... 64, 64, 64... seconds.
-  @staticmethod
-  @retrying.retry(
-      stop_max_attempt_number=23,
-      retry_on_exception=_retry_api_check,
-      wait_exponential_multiplier=1000,
-      wait_exponential_max=64000)
-  def execute(api):
-    return api.execute()
 
 
 class _Pipelines(object):
@@ -560,7 +372,7 @@ class _Pipelines(object):
                 'minimumRamGb': min_ram,
                 'bootDiskSizeGb': boot_disk_size,
                 'preemptible': preemptible,
-                'zones': _get_zones(zones),
+                'zones': google_base.get_zones(zones),
                 'acceleratorType': accelerator_type,
                 'acceleratorCount': accelerator_count,
 
@@ -670,7 +482,7 @@ class _Pipelines(object):
 
   @staticmethod
   def run_pipeline(service, pipeline):
-    return _Api.execute(service.pipelines().run(body=pipeline))
+    return google_base.Api.execute(service.pipelines().run(body=pipeline))
 
 
 class _Operations(object):
@@ -807,7 +619,7 @@ class _Operations(object):
           filter=ops_filter,
           pageToken=page_token,
           pageSize=page_size)
-      response = _Api.execute(api)
+      response = google_base.Api.execute(api)
 
       ops = response.get('operations', [])
       for op in ops:
@@ -928,33 +740,8 @@ class GoogleJobProvider(base.JobProvider):
     self._project = project
     self._zones = zones
 
-    self._service = self._setup_service(credentials)
-
-  # Exponential backoff retrying API discovery.
-  # Maximum 23 retries.  Wait 1, 2, 4 ... 64, 64, 64... seconds.
-  @classmethod
-  @retrying.retry(
-      stop_max_attempt_number=23,
-      retry_on_exception=_retry_api_check,
-      wait_exponential_multiplier=1000,
-      wait_exponential_max=64000)
-  def _do_setup_service(cls, credentials):
-    return apiclient.discovery.build(
-        'genomics', 'v1alpha2', credentials=credentials)
-
-  @classmethod
-  def _setup_service(cls, credentials=None):
-    """Configures genomics API client.
-
-    Args:
-      credentials: credentials to be used for the gcloud API calls.
-
-    Returns:
-      A configured Google Genomics API client with appropriate credentials.
-    """
-    if not credentials:
-      credentials = GoogleCredentials.get_application_default()
-    return cls._do_setup_service(credentials)
+    self._service = google_base.setup_service('genomics', 'v1alpha2',
+                                              credentials)
 
   def prepare_job_metadata(self, script, job_name, user_id, create_time):
     """Returns a dictionary of metadata fields for the job."""
@@ -965,14 +752,14 @@ class GoogleJobProvider(base.JobProvider):
     # 'job-name' label (and so the value must be normalized).
     if job_name:
       pipeline_name = job_name
-      job_name_value = _Label.convert_to_label_chars(job_name)
+      job_name_value = job_model.convert_to_label_chars(job_name)
     else:
       pipeline_name = os.path.basename(script)
-      job_name_value = _Label.convert_to_label_chars(
+      job_name_value = job_model.convert_to_label_chars(
           pipeline_name.split('.', 1)[0])
 
     # The user-id will get set as a label
-    user_id = _Label.convert_to_label_chars(user_id)
+    user_id = job_model.convert_to_label_chars(user_id)
 
     # Now build the job-id. We want the job-id to be expressive while also
     # having a low-likelihood of collisions.
@@ -991,7 +778,7 @@ class GoogleJobProvider(base.JobProvider):
 
     # Standard version is MAJOR.MINOR(.PATCH). This will convert the version
     # string to "vMAJOR-MINOR(-PATCH)". Example; "0.1.0" -> "v0-1-0".
-    version = _Label.convert_to_label_chars('v%s' % DSUB_VERSION)
+    version = job_model.convert_to_label_chars('v%s' % DSUB_VERSION)
     return {
         'pipeline-name': pipeline_name,
         'job-name': job_name_value,
@@ -1002,12 +789,14 @@ class GoogleJobProvider(base.JobProvider):
 
   def _build_pipeline_labels(self, job_metadata, task_metadata):
     labels = {
-        _Label(name, job_metadata[name])
+        google_base.Label(name, job_metadata[name])
         for name in ['job-name', 'job-id', 'user-id', 'dsub-version']
     }
 
     if task_metadata.get('task-id') is not None:
-      labels.add(_Label('task-id', 'task-%d' % task_metadata.get('task-id')))
+      labels.add(
+          google_base.Label('task-id',
+                            'task-%d' % task_metadata.get('task-id')))
 
     return labels
 

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -33,7 +33,7 @@ from .._dsub_version import DSUB_VERSION
 import apiclient.discovery
 import apiclient.errors
 
-# TODO(b/68858502) Fix the use of relative imports throughout this library
+# TODO(b/68858502) Remove the use of relative imports throughout this library
 from ..lib import dsub_util
 from ..lib import job_model
 from ..lib import param_util

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -1089,6 +1089,23 @@ class GoogleOperation(base.Task):
     elif field == 'last-update':
       status, last_update = self.operation_status_message()
       value = last_update
+    elif field == 'provider':
+      return _PROVIDER_NAME
+    elif field == 'provider-attributes':
+      # Use soft getting of keys to address a race condition and to
+      # pull the null values found in jobs that fail prior to scheduling.
+      gce_data = metadata.get('runtimeMetadata', {}).get('computeEngine', {})
+      if 'machineType' in gce_data:
+        machine_type = gce_data.get('machineType').rpartition('/')[2]
+      else:
+        machine_type = None
+      instance_name = gce_data.get('instanceName')
+      instance_zone = gce_data.get('zone')
+      value = {
+          'machine-type': machine_type,
+          'instance-name': instance_name,
+          'zone': instance_zone,
+      }
     else:
       raise ValueError('Unsupported field: "%s"' % field)
 

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -1,0 +1,220 @@
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Base class for the google and google_v2 providers.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import socket
+import sys
+
+import apiclient.discovery
+import apiclient.errors
+from ..lib import job_model
+from oauth2client.client import GoogleCredentials
+from oauth2client.client import HttpAccessTokenRefreshError
+import retrying
+
+# Transient errors for the Google APIs should not cause them to fail.
+# There are a set of HTTP and socket errors which we automatically retry.
+#  429: too frequent polling
+#  50x: backend error
+TRANSIENT_HTTP_ERROR_CODES = set([429, 500, 503, 504])
+
+# Socket error 104 (connection reset) should also be retried
+TRANSIENT_SOCKET_ERROR_CODES = set([104])
+
+# List of Compute Engine zones, which enables simple wildcard expansion.
+# We could look this up dynamically, but new zones come online
+# infrequently enough, this is easy to keep up with.
+# Also - the Pipelines API may one day directly support zone wildcards.
+#
+# To refresh this list:
+#   gcloud compute zones list --format='value(name)' \
+#     | sort | awk '{ printf "    '\''%s'\'',\n", $1 }'
+_ZONES = [
+    'asia-east1-a',
+    'asia-east1-b',
+    'asia-east1-c',
+    'asia-northeast1-a',
+    'asia-northeast1-b',
+    'asia-northeast1-c',
+    'asia-south1-a',
+    'asia-south1-b',
+    'asia-south1-c',
+    'asia-southeast1-a',
+    'asia-southeast1-b',
+    'australia-southeast1-a',
+    'australia-southeast1-b',
+    'australia-southeast1-c',
+    'europe-west1-b',
+    'europe-west1-c',
+    'europe-west1-d',
+    'europe-west2-a',
+    'europe-west2-b',
+    'europe-west2-c',
+    'europe-west3-a',
+    'europe-west3-b',
+    'europe-west3-c',
+    'europe-west4-a',
+    'europe-west4-b',
+    'europe-west4-c',
+    'northamerica-northeast1-a',
+    'northamerica-northeast1-b',
+    'northamerica-northeast1-c',
+    'southamerica-east1-a',
+    'southamerica-east1-b',
+    'southamerica-east1-c',
+    'us-central1-a',
+    'us-central1-b',
+    'us-central1-c',
+    'us-central1-f',
+    'us-east1-b',
+    'us-east1-c',
+    'us-east1-d',
+    'us-east4-a',
+    'us-east4-b',
+    'us-east4-c',
+    'us-west1-a',
+    'us-west1-b',
+    'us-west1-c',
+]
+
+
+def _print_error(msg):
+  """Utility routine to emit messages to stderr."""
+  print(msg, file=sys.stderr)
+
+
+def get_zones(input_list):
+  """Returns a list of zones based on any wildcard input.
+
+  This function is intended to provide an easy method for producing a list
+  of desired zones for a pipeline to run in.
+
+  The Pipelines API default zone list is "any zone". The problem with
+  "any zone" is that it can lead to incurring Cloud Storage egress charges
+  if the GCE zone selected is in a different region than the GCS bucket.
+  See https://cloud.google.com/storage/pricing#network-egress.
+
+  A user with a multi-region US bucket would want to pipelines to run in
+  a "us-*" zone.
+  A user with a regional bucket in US would want to restrict pipelines to
+  run in a zone in that region.
+
+  Rarely does the specific zone matter for a pipeline.
+
+  This function allows for a simple short-hand such as:
+     [ "us-*" ]
+     [ "us-central1-*" ]
+  These examples will expand out to the full list of US and us-central1 zones
+  respectively.
+
+  Args:
+    input_list: list of zone names/patterns
+
+  Returns:
+    A list of zones, with any wildcard zone specifications expanded.
+  """
+
+  output_list = []
+
+  for zone in input_list:
+    if zone.endswith('*'):
+      prefix = zone[:-1]
+      output_list.extend([z for z in _ZONES if z.startswith(prefix)])
+    else:
+      output_list.append(zone)
+
+  return output_list
+
+
+class Label(job_model.LabelParam):
+  """Name/value label metadata for a Google Genomics pipeline.
+
+  Attributes:
+    name (str): the label name.
+    value (str): the label value (optional).
+  """
+  _allow_reserved_keys = True
+  __slots__ = ()
+
+
+def retry_api_check(exception):
+  """Return True if we should retry. False otherwise.
+
+  Args:
+    exception: An exception to test for transience.
+
+  Returns:
+    True if we should retry. False otherwise.
+  """
+  _print_error('Exception %s: %s' % (type(exception).__name__, str(exception)))
+
+  if isinstance(exception, apiclient.errors.HttpError):
+    if exception.resp.status in TRANSIENT_HTTP_ERROR_CODES:
+      return True
+
+  if isinstance(exception, socket.error):
+    if exception.errno in TRANSIENT_SOCKET_ERROR_CODES:
+      return True
+
+  if isinstance(exception, HttpAccessTokenRefreshError):
+    return True
+
+  return False
+
+
+# Exponential backoff retrying API discovery.
+# Maximum 23 retries.  Wait 1, 2, 4 ... 64, 64, 64... seconds.
+@retrying.retry(
+    stop_max_attempt_number=23,
+    retry_on_exception=retry_api_check,
+    wait_exponential_multiplier=1000,
+    wait_exponential_max=64000)
+def setup_service(api_name, api_version, credentials=None):
+  """Configures genomics API client.
+
+  Args:
+    api_name: Name of the Google API (for example: "genomics")
+    api_version: Version of the API (for example: "v2alpha1")
+    credentials: Credentials to be used for the gcloud API calls.
+
+  Returns:
+    A configured Google Genomics API client with appropriate credentials.
+  """
+  if not credentials:
+    credentials = GoogleCredentials.get_application_default()
+  return apiclient.discovery.build(
+      api_name, api_version, credentials=credentials)
+
+
+class Api(object):
+
+  # Exponential backoff retrying API execution.
+  # Maximum 23 retries.  Wait 1, 2, 4 ... 64, 64, 64... seconds.
+  @staticmethod
+  @retrying.retry(
+      stop_max_attempt_number=23,
+      retry_on_exception=retry_api_check,
+      wait_exponential_multiplier=1000,
+      wait_exponential_max=64000)
+  def execute(api):
+    return api.execute()
+
+
+if __name__ == '__main__':
+  pass

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -18,9 +18,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import socket
 import sys
 
+from .._dsub_version import DSUB_VERSION
 import apiclient.discovery
 import apiclient.errors
 from ..lib import job_model
@@ -129,6 +131,8 @@ def get_zones(input_list):
   Returns:
     A list of zones, with any wildcard zone specifications expanded.
   """
+  if not input_list:
+    return []
 
   output_list = []
 
@@ -151,6 +155,64 @@ class Label(job_model.LabelParam):
   """
   _allow_reserved_keys = True
   __slots__ = ()
+
+
+def build_pipeline_labels(job_metadata, task_metadata):
+  """Build a dictionary of standard job and task labels."""
+  labels = {
+      Label(name, job_metadata[name])
+      for name in ['job-name', 'job-id', 'user-id', 'dsub-version']
+  }
+
+  if task_metadata.get('task-id') is not None:
+    labels.add(Label('task-id', 'task-%d' % task_metadata.get('task-id')))
+
+  return labels
+
+
+def prepare_job_metadata(script, job_name, user_id, create_time):
+  """Returns a dictionary of metadata fields for the job."""
+
+  # The name of the pipeline gets set into the ephemeralPipeline.name as-is.
+  # The default name of the pipeline is the script name
+  # The name of the job is derived from the job_name and gets set as a
+  # 'job-name' label (and so the value must be normalized).
+  if job_name:
+    pipeline_name = job_name
+    job_name_value = job_model.convert_to_label_chars(job_name)
+  else:
+    pipeline_name = os.path.basename(script)
+    job_name_value = job_model.convert_to_label_chars(
+        pipeline_name.split('.', 1)[0])
+
+  # The user-id will get set as a label
+  user_id = job_model.convert_to_label_chars(user_id)
+
+  # Now build the job-id. We want the job-id to be expressive while also
+  # having a low-likelihood of collisions.
+  #
+  # For expressiveness, we:
+  # * use the job name (truncated at 10 characters).
+  # * insert the user-id
+  # * add a datetime value
+  # To have a high likelihood of uniqueness, the datetime value is out to
+  # hundredths of a second.
+  #
+  # The full job-id is:
+  #   <job-name>--<user-id>--<timestamp>
+  job_id = '%s--%s--%s' % (job_name_value[:10], user_id,
+                           create_time.strftime('%y%m%d-%H%M%S-%f')[:16])
+
+  # Standard version is MAJOR.MINOR(.PATCH). This will convert the version
+  # string to "vMAJOR-MINOR(-PATCH)". Example; "0.1.0" -> "v0-1-0".
+  version = job_model.convert_to_label_chars('v%s' % DSUB_VERSION)
+  return {
+      'pipeline-name': pipeline_name,
+      'job-name': job_name_value,
+      'job-id': job_id,
+      'user-id': user_id,
+      'dsub-version': version,
+  }
 
 
 def retry_api_check(exception):

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1,0 +1,63 @@
+# Copyright 2018 Verily Life Sciences. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provider for running jobs on Google Cloud Platform.
+
+This module implements job creation, listing, and canceling using the
+Google Genomics Pipelines and Operations APIs v2alpha1.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from . import base
+
+_PROVIDER_NAME = 'google-v2'
+
+
+class GoogleV2JobProvider(base.JobProvider):
+  """dsub provider implementation managing Jobs on Google Cloud."""
+
+  def __init__(self):
+    pass
+
+  def submit_job(self, job_descriptor):
+    pass
+
+  def delete_jobs(self,
+                  user_ids,
+                  job_ids,
+                  task_ids,
+                  labels,
+                  create_time_min=None,
+                  create_time_max=None):
+    pass
+
+  def prepare_job_metadata(self, script, job_name, user_id, create_time):
+    pass
+
+  def lookup_job_tasks(self,
+                       statuses,
+                       user_ids=None,
+                       job_ids=None,
+                       job_names=None,
+                       task_ids=None,
+                       labels=None,
+                       create_time_min=None,
+                       create_time_max=None,
+                       max_tasks=0):
+    pass
+
+
+if __name__ == '__main__':
+  pass

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Verily Life Sciences. All Rights Reserved.
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import print_function
 
 from . import base
+from . import google_base
 
 _PROVIDER_NAME = 'google-v2'
 
@@ -28,8 +29,13 @@ _PROVIDER_NAME = 'google-v2'
 class GoogleV2JobProvider(base.JobProvider):
   """dsub provider implementation managing Jobs on Google Cloud."""
 
-  def __init__(self):
-    pass
+  def __init__(self, project, regions=None, zones=None, credentials=None):
+    self._project = project
+    self._regions = regions
+    self._zones = zones
+
+    self._service = google_base.setup_service('genomics', 'v2alpha1',
+                                              credentials)
 
   def submit_job(self, job_descriptor):
     pass

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -15,30 +15,168 @@
 
 This module implements job creation, listing, and canceling using the
 Google Genomics Pipelines and Operations APIs v2alpha1.
+
+Status: *early* development
+Much still to be done just on launching a pipeline, including localization,
+delocalization, logging.
+Need to figure out support for generic scripts (currently only supports bash).
+Then dstat/ddel support.
 """
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
+
 from . import base
 from . import google_base
+from . import google_v2_pipelines
+
+from ..lib import dsub_util
+from ..lib import job_model
+from ..lib import param_util
 
 _PROVIDER_NAME = 'google-v2'
+
+# Create file provider whitelist.
+_SUPPORTED_FILE_PROVIDERS = frozenset([job_model.P_GCS])
+_SUPPORTED_LOGGING_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
+_SUPPORTED_INPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
+_SUPPORTED_OUTPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 
 
 class GoogleV2JobProvider(base.JobProvider):
   """dsub provider implementation managing Jobs on Google Cloud."""
 
-  def __init__(self, project, regions=None, zones=None, credentials=None):
+  def __init__(self, verbose, dry_run, project, credentials=None):
+    self._verbose = verbose
+    self._dry_run = dry_run
+
     self._project = project
-    self._regions = regions
-    self._zones = zones
 
     self._service = google_base.setup_service('genomics', 'v2alpha1',
                                               credentials)
 
-  def submit_job(self, job_descriptor):
-    pass
+  def _build_pipeline_request(self, task_view):
+    """Returns a Pipeline objects for the job."""
+    job_metadata = task_view.job_metadata
+    job_params = task_view.job_params
+    job_resources = task_view.job_resources
+    task_metadata = task_view.task_descriptors[0].task_metadata
+    task_params = task_view.task_descriptors[0].task_params
+
+    script = task_view.job_metadata['script']
+
+    labels = {
+        label.name: label.value if label.value else '' for label in
+        google_base.build_pipeline_labels(job_metadata, task_metadata)
+        | job_params['labels'] | task_params['labels']
+    }
+
+    # The list of "actions" is:
+    #   1- localize objects from Cloud Storage to block storage
+    #   2- execute user command
+    #   3- delocalize objects from block storage to Cloud Storage
+
+    # For now, the actions just execute a user command as POC.
+    actions = [
+        google_v2_pipelines.build_action(
+            name=script.name,
+            image_uri=job_resources.image,
+            entrypoint='/bin/bash',
+            commands=['-c', script.value]),
+    ]
+
+    disks = None
+    network = google_v2_pipelines.build_network(None, None)
+    machine_type = job_resources.machine_type or job_model.DEFAULT_MACHINE_TYPE
+    service_account = google_v2_pipelines.build_service_account(
+        'default', job_resources.scopes or job_model.DEFAULT_SCOPES)
+
+    resources = google_v2_pipelines.build_resources(
+        self._project,
+        job_resources.regions,
+        google_base.get_zones(job_resources.zones),
+        google_v2_pipelines.build_machine(
+            network=network,
+            machine_type=machine_type,
+            preemptible=job_resources.preemptible,
+            service_account=service_account,
+            boot_disk_size_gb=job_resources.boot_disk_size,
+            disks=disks,
+            labels=labels),
+    )
+
+    pipeline = google_v2_pipelines.build_pipeline(actions, resources, None)
+
+    return {'pipeline': pipeline, 'labels': labels}
+
+  def _submit_pipeline(self, request):
+    operation = google_base.Api.execute(
+        self._service.pipelines().run(body=request))
+    if self._verbose:
+      print('Launched operation {}'.format(operation['name']))
+
+    return GoogleOperation(operation).get_field('task-id')
+
+  def submit_job(self, job_descriptor, skip_if_output_present):
+    """Submit the job (or tasks) to be executed.
+
+    Args:
+      job_descriptor: all parameters needed to launch all job tasks
+      skip_if_output_present: (boolean) if true, skip tasks whose output
+        is present (see --skip flag for more explanation).
+
+    Returns:
+      A dictionary containing the 'user-id', 'job-id', and 'task-id' list.
+      For jobs that are not task array jobs, the task-id list should be empty.
+
+    Raises:
+      ValueError: if job resources or task data contain illegal values.
+    """
+    # Validate task data and resources.
+    param_util.validate_submit_args_or_fail(
+        job_descriptor,
+        provider_name=_PROVIDER_NAME,
+        input_providers=_SUPPORTED_INPUT_PROVIDERS,
+        output_providers=_SUPPORTED_OUTPUT_PROVIDERS,
+        logging_providers=_SUPPORTED_LOGGING_PROVIDERS)
+
+    # Prepare and submit jobs.
+    launched_tasks = []
+    requests = []
+    for task_view in job_model.task_view_generator(job_descriptor):
+
+      job_params = task_view.job_params
+      task_params = task_view.task_descriptors[0].task_params
+
+      outputs = job_params['outputs'] | task_params['outputs']
+      if skip_if_output_present:
+        # check whether the output's already there
+        if dsub_util.outputs_are_present(outputs):
+          print('Skipping task because its outputs are present')
+          continue
+
+      request = self._build_pipeline_request(task_view)
+
+      if self._dry_run:
+        requests.append(request)
+      else:
+        task_id = self._submit_pipeline(request)
+        launched_tasks.append(task_id)
+
+    # If this is a dry-run, emit all the pipeline request objects
+    if self._dry_run:
+      print(json.dumps(requests, indent=2, sort_keys=True))
+
+    if not requests and not launched_tasks:
+      return {'job-id': dsub_util.NO_JOB}
+
+    return {
+        'job-id': job_descriptor.job_metadata['job-id'],
+        'user-id': job_descriptor.job_metadata['user-id'],
+        'task-id': [task_id for task_id in launched_tasks if task_id],
+    }
 
   def delete_jobs(self,
                   user_ids,
@@ -49,8 +187,13 @@ class GoogleV2JobProvider(base.JobProvider):
                   create_time_max=None):
     pass
 
-  def prepare_job_metadata(self, script, job_name, user_id, create_time):
+  def get_tasks_completion_messages(self, tasks):
     pass
+
+  def prepare_job_metadata(self, script, job_name, user_id, create_time):
+    """Returns a dictionary of metadata fields for the job."""
+    return google_base.prepare_job_metadata(script, job_name, user_id,
+                                            create_time)
 
   def lookup_job_tasks(self,
                        statuses,
@@ -63,6 +206,29 @@ class GoogleV2JobProvider(base.JobProvider):
                        create_time_max=None,
                        max_tasks=0):
     pass
+
+
+class GoogleOperation(base.Task):
+  """Task wrapper around a Pipelines API operation object."""
+
+  def __init__(self, operation_data):
+    self._op = operation_data
+
+  def get_field(self, field, default=None):
+    """Returns a value from the operation for a specific set of field names.
+
+    Args:
+      field: a dsub-specific job metadata key
+      default: default value to return if field does not exist or is empty.
+
+    Returns:
+      A text string for the field or a list for 'inputs'.
+
+    Raises:
+      ValueError: if the field label is not supported by the operation
+    """
+
+    return 'not implemented'
 
 
 if __name__ == '__main__':

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -1,0 +1,162 @@
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility routines for constructing a Google Genomics Pipelines v2 API request.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+def build_network(name, use_private_address):
+  return {
+      'name': name,
+      'usePrivateAddress': use_private_address,
+  }
+
+
+def build_disks(name, size_gb):
+  return [{
+      'name': name,
+      'sizeGb': size_gb,
+  }]
+
+
+def build_service_account(email, scopes):
+  return {
+      'email': email,
+      'scopes': scopes,
+  }
+
+
+def build_machine(network=None,
+                  machine_type=None,
+                  preemptible=None,
+                  service_account=None,
+                  boot_disk_size_gb=None,
+                  disks=None,
+                  labels=None):
+  """Build a VirtualMachine object for a Pipeline request.
+
+  Args:
+    network (dict): Network details for the pipeline to run in.
+    machine_type (str): GCE Machine Type string for the pipeline.
+    preemptible (bool): Use a preemptible VM for the job.
+    service_account (dict): Service account configuration for the VM.
+    boot_disk_size_gb (int): Boot disk size in GB.
+    disks (list[dict]): List of disks to mount.
+    labels (dict[string, string]): Labels for the VM.
+
+  Returns:
+    An object representing a VirtualMachine.
+  """
+  return {
+      'network': network,
+      'machineType': machine_type,
+      'preemptible': preemptible,
+      'serviceAccount': service_account,
+      'bootDiskSizeGb': boot_disk_size_gb,
+      'disks': disks,
+      'labels': labels,
+  }
+
+
+def build_resources(project=None,
+                    regions=None,
+                    zones=None,
+                    virtual_machine=None):
+  """Build a Resources object for a Pipeline request.
+
+  Args:
+    project (str): Cloud project for the Pipeline to run in.
+    regions (List[str]): List of regions for the pipeline to run in.
+    zones (List[str]): List of zones for the pipeline to run in.
+    virtual_machine(str): Virtual machine type string.
+
+  Returns:
+    An object representing a Resource.
+  """
+
+  return {
+      'projectId': project,
+      'regions': regions,
+      'zones': zones,
+      'virtualMachine': virtual_machine,
+  }
+
+
+def build_action(name=None,
+                 image_uri=None,
+                 commands=None,
+                 entrypoint=None,
+                 environment=None,
+                 pid_namespace=None,
+                 flags=None,
+                 port_mappings=None,
+                 mounts=None,
+                 labels=None):
+  """Build an Action object for a Pipeline request.
+
+  Args:
+    name (str): An optional name for the container.
+    image_uri (str): The URI to pull the container image from.
+    commands (List[str]): commands and arguments to run inside the container.
+    entrypoint (str): overrides the ENTRYPOINT specified in the container.
+    environment (dict[str,str]): The environment to pass into the container.
+    pid_namespace (str): The PID namespace to run the action inside.
+    flags (str): Flags that control the execution of this action.
+    port_mappings (dict[int, int]): A map of container to host port mappings for
+      this container.
+    mounts (List): A list of mounts to make available to the action.
+    labels (dict[str]): Labels to associate with the action.
+
+  Returns:
+    An object representing an Action resource.
+  """
+
+  return {
+      'name': name,
+      'imageUri': image_uri,
+      'commands': commands,
+      'entrypoint': entrypoint,
+      'environment': environment,
+      'pidNamespace': pid_namespace,
+      'flags': flags,
+      'portMappings': port_mappings,
+      'mounts': mounts,
+      'labels': labels,
+  }
+
+
+def build_pipeline(actions, resources, environment):
+  """Build an Pipeline argument for a Pipeline request.
+
+  Args:
+    actions (List): A list of actions to execute.
+    resources (dict): An object indicating pipeline resources.
+    environment (dict[str,str]): The environment to pass into the container.
+
+  Returns:
+    An object representing a Pipelines Resource.
+  """
+
+  return {
+      'actions': actions,
+      'resources': resources,
+      'environment': environment,
+  }
+
+
+if __name__ == '__main__':
+  pass

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -697,9 +697,9 @@ class LocalJobProvider(base.JobProvider):
     """Return a dictionary of environment variables for the VM."""
     ret = {}
     for i in inputs:
-      ret[i.name] = _DATA_MOUNT_POINT + '/' + i.docker_path
+      ret[i.name] = _DATA_MOUNT_POINT + '/' + i.docker_path if i.value else ''
     for o in outputs:
-      ret[o.name] = _DATA_MOUNT_POINT + '/' + o.docker_path
+      ret[o.name] = _DATA_MOUNT_POINT + '/' + o.docker_path if o.value else ''
     return ret
 
   def _localize_inputs_recursive_command(self, task_dir, inputs):
@@ -737,7 +737,7 @@ class LocalJobProvider(base.JobProvider):
     """Returns a command that will stage inputs."""
     commands = []
     for i in inputs:
-      if i.recursive:
+      if i.recursive or not i.value:
         continue
 
       source_file_path = i.uri
@@ -763,6 +763,8 @@ class LocalJobProvider(base.JobProvider):
     os.makedirs(task_dir + '/' + _DATA_SUBDIR + '/' + _WORKING_DIR)
     os.makedirs(task_dir + '/' + _DATA_SUBDIR + '/tmp')
     for o in outputs:
+      if not o.value:
+        continue
       local_file_path = task_dir + '/' + _DATA_SUBDIR + '/' + o.docker_path
       # makedirs errors out if the folder already exists, so check.
       if not os.path.isdir(os.path.dirname(local_file_path)):
@@ -787,7 +789,7 @@ class LocalJobProvider(base.JobProvider):
     """Copy outputs from local disk to GCS."""
     commands = []
     for o in outputs:
-      if o.recursive:
+      if o.recursive or not o.value:
         continue
 
       # The destination path is o.uri.path, which is the target directory

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -885,6 +885,10 @@ class LocalTask(base.Task):
       for field in ['outputs', 'output-recursives']:
         items = self._get_job_and_task_param(job_params, task_params, field)
         value.update({item.name: item.value for item in items})
+    elif field == 'provider':
+      return _PROVIDER_NAME
+    elif field == 'provider-attributes':
+      value = {}
     else:
       # Convert the raw Task object to a dict.
       # With the exception of the "status' fields, the dsub field names map

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -17,12 +17,14 @@ import argparse
 import os
 
 from . import google
+from . import google_v2
 from . import local
 from . import test_fails
 
 
 PROVIDER_NAME_MAP = {
     google.GoogleJobProvider: 'google',
+    google_v2.GoogleV2JobProvider: 'google-v2',
     local.LocalJobProvider: 'local',
     test_fails.FailsJobProvider: 'test-fails',
 }
@@ -37,6 +39,8 @@ def get_provider(args, resources):
     return google.GoogleJobProvider(
         getattr(args, 'verbose', False),
         getattr(args, 'dry_run', False), args.project)
+  elif provider == 'google-v2':
+    return google_v2.GoogleV2JobProvider()
   elif provider == 'local':
     return local.LocalJobProvider(resources)
   elif provider == 'test-fails':
@@ -69,9 +73,10 @@ def create_parser(prog):
   parser.add_argument(
       '--provider',
       default='google',
-      choices=['local', 'google', 'test-fails'],
+      choices=['local', 'google', 'google-v2', 'test-fails'],
       help="""Job service provider. Valid values are "google" (Google's
-        Pipeline API) and "local" (local Docker execution). "test-*" providers
+        Pipeline API) and "local" (local Docker execution). "google-v2"
+        (Google's Pipelines API v2alpha1 is in development). "test-*" providers
         are for testing purposes only.""",
       metavar='PROVIDER')
 
@@ -102,6 +107,8 @@ def get_dstat_provider_args(provider, project):
   """A string with the arguments to point dstat to the same provider+project."""
   provider_name = get_provider_name(provider)
   if provider_name == 'google':
+    return ' --project %s' % project
+  elif provider_name == 'google-v2':
     return ' --project %s' % project
   elif provider_name == 'local':
     return ' --provider local'

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -40,7 +40,9 @@ def get_provider(args, resources):
         getattr(args, 'verbose', False),
         getattr(args, 'dry_run', False), args.project)
   elif provider == 'google-v2':
-    return google_v2.GoogleV2JobProvider()
+    return google_v2.GoogleV2JobProvider(
+        getattr(args, 'verbose', False), getattr(args, 'dry_run', False),
+        args.project)
   elif provider == 'local':
     return local.LocalJobProvider(resources)
   elif provider == 'test-fails':

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -161,7 +161,7 @@ def format_logging_uri(uri, job_metadata, task_metadata):
   For (2), the file name generated is {job-id}, or for --tasks jobs, it is
   {job-id}.{task-id}.
 
-  In addition, full task metadata subsitition is supported. The URI
+  In addition, full task metadata substitution is supported. The URI
   may include substitution strings such as
   "{job-id}", "{task-id}", "{job-name}", and "{user-id}".
 

--- a/test/integration/e2e_dstat.sh
+++ b/test/integration/e2e_dstat.sh
@@ -59,6 +59,39 @@ function verify_dstat_output() {
 readonly -f verify_dstat_output
 
 
+function verify_dstat_google_provider_fields() {
+   local dstat_out="${1}"
+   for (( job=0; job < 3; job++ )); do
+     # Skip the test if the job's state is not yet running or completed.
+     local status="$(python "${SCRIPT_DIR}"/get_data_value.py "yaml" "${dstat_out}" "[${job}].status")"
+     if ! [[ "${status}" =~ ^(RUNNING|SUCCESS)$ ]]; then
+       echo "  - NOTICE: status '${status}' may not have compute metadata,"
+       echo "            skipping provider fields tests."
+       exit 0
+     fi
+
+     # Run the provider test.
+     local job_name="$(python "${SCRIPT_DIR}"/get_data_value.py "yaml" "${dstat_out}" "[${job}].job-name")"
+     local job_provider="$(python "${SCRIPT_DIR}"/get_data_value.py "yaml" "${dstat_out}" "[${job}].provider")"
+
+     # Validate provider.
+     if [[ "${job_provider}" != "${DSUB_PROVIDER}" ]]; then
+       echo "  - FAILURE: provider ${job_provider} does not match '${DSUB_PROVIDER}'"
+       echo "${dstat_out}"
+       exit 1
+     fi
+     local job_zone=$(python "${SCRIPT_DIR}"/get_data_value.py "yaml" "${dstat_out}" "[${job}].provider-attributes.zone")
+     if ! [[ "${job_zone}" =~ ^[a-z]{1,4}-[a-z]{2,15}[0-9]-[a-z]$ ]]; then
+       echo "  - FAILURE: Job zone ${job_zone} for job ${job_name} not valid."
+       echo "${dstat_out}"
+       exit 1
+     fi
+   done
+   echo "  - google provider fields verified"
+}
+readonly -f verify_dstat_google_provider_fields
+
+
 # This test is not sensitive to the output of the dsub job.
 # Set the ALLOW_DIRTY_TESTS environment variable to 1 in your shell to
 # run this test without first emptying the output and logging directories.
@@ -98,6 +131,12 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Checking dstat (by job-name)..."
 
+  # For the google provider, sleep briefly to allow the Pipelines v1
+  # to set the compute properties, which occurs shortly after pipeline submit.
+  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
+    sleep 2
+  fi
+
   if ! DSTAT_OUTPUT="$(run_dstat --status 'RUNNING' 'SUCCESS' --full --names "${RUNNING_JOB_NAME_2}" "${RUNNING_JOB_NAME}" "${COMPLETED_JOB_NAME}" --label "test-token=${TEST_TOKEN}")"; then
     echo "dstat exited with a non-zero exit code!"
     echo "Output:"
@@ -106,6 +145,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   fi
 
   verify_dstat_output "${DSTAT_OUTPUT}"
+  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
+    echo "Checking dstat google provider fields"
+    verify_dstat_google_provider_fields "${DSTAT_OUTPUT}"
+  fi
 
   echo "Checking dstat (by job-id: default)..."
 
@@ -144,6 +187,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   fi
 
   verify_dstat_output "${DSTAT_OUTPUT}"
+  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
+    echo "Checking dstat google provider fields"
+    verify_dstat_google_provider_fields "${DSTAT_OUTPUT}"
+  fi
 
   echo "Checking dstat (by repeated job-ids: full)..."
 

--- a/test/integration/e2e_env_tasks.sh
+++ b/test/integration/e2e_env_tasks.sh
@@ -41,10 +41,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   # Also include 0 to make sure it is passed through correctly as
   # a string ("0") and not dropped as int (0).
   util::write_tsv_file "${TASKS_FILE}" '
-  --env TASK_VAR1\t--env TASK_VAR2\t--env TASK_VAR_ZERO\t--env TASK_VAR3
-  \tVAL2_TASK1\t0\tVAL3_TASK1
-  VAL1_TASK2\t\t0\tVAL3_TASK2
-  VAL1_TASK3\tVAL2_TASK3\t0\t
+  --env TASK_VAR1\t--env TASK_VAR2\t--env TASK_VAR_ZERO\t--input TASK_VAR_IO1\t--input-recursive TASK_VAR_IO2\t--output TASK_VAR_IO3\t--output-recursive TASK_VAR_IO4\t--env TASK_VAR3
+  \tVAL2_TASK1\t0\t\t\t\t\tVAL3_TASK1
+  VAL1_TASK2\t\t0\t\t\t\t\tVAL3_TASK2
+  VAL1_TASK3\tVAL2_TASK3\t0\t\t\t\t\t
   '
 
   echo "Launching pipeline..."
@@ -58,6 +58,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
     --env VAR4="VAL4 (four)" \
     --env VAR5="VAL5" \
     --env VAR6= \
+    --input VAR_IO1= \
+    --input-recursive VAR_IO2= \
+    --output VAR_IO3= \
+    --output-recursive VAR_IO4= \
     --env VAR_ZERO=0 \
     --tasks "${TASKS_FILE}" \
     --wait
@@ -81,6 +85,10 @@ for ((TASK_ID=1; TASK_ID <= NUM_TASKS; TASK_ID++)); do
       TASK_VAR1=%s
       TASK_VAR2=%s
       TASK_VAR3=%s
+      TASK_VAR_IO1=
+      TASK_VAR_IO2=
+      TASK_VAR_IO3=
+      TASK_VAR_IO4=
       TASK_VAR_ZERO=0
       VAR1=VAL1
       VAR2=VAL2
@@ -88,6 +96,10 @@ for ((TASK_ID=1; TASK_ID <= NUM_TASKS; TASK_ID++)); do
       VAR4=VAL4 (four)
       VAR5=VAL5
       VAR6=
+      VAR_IO1=
+      VAR_IO2=
+      VAR_IO3=
+      VAR_IO4=
       VAR_ZERO=0
       ' "${TASK_VAR1}" "${TASK_VAR2}" "${TASK_VAR3}" | \
     grep -v '^$' | \

--- a/test/integration/test_setup.sh
+++ b/test/integration/test_setup.sh
@@ -94,6 +94,14 @@ function dsub_google() {
     "${@}"
 }
 
+function dsub_google-v2() {
+  dsub \
+    --provider google-v2 \
+    --project "${PROJECT_ID}" \
+    --logging "${LOGGING_OVERRIDE:-${LOGGING}}" \
+    "${@}"
+}
+
 function dsub_local() {
   dsub \
     --provider local \

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# unit_flags.google-v2.sh
+#
+# Collection of unit tests for dsub command-line flags
+# specific to the google-v2 provider.
+
+readonly SCRIPT_DIR="$(dirname "${0}")"
+
+# Do standard test setup
+source "${SCRIPT_DIR}/test_setup_unit.sh"
+
+function call_dsub() {
+  run_dsub \
+    "${@}" \
+    --dry-run \
+    1> "${TEST_STDOUT}" \
+    2> "${TEST_STDERR}"
+}
+readonly -f call_dsub
+
+# Define tests
+
+function test_with_neither_region_nor_zone() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"'; then
+
+    2>&1 echo "Neither regions nor zones specified - not detected"
+
+    test_failed "${subtest}"
+  else
+
+    assert_output_empty
+
+    assert_err_contains \
+      "ValueError: Exactly one of --regions and --zones must be specified"
+
+    test_passed "${subtest}"
+  fi
+}
+readonly -f test_with_neither_region_nor_zone
+
+function test_with_region_and_zone() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --zones us-central1-f \
+    --regions us-central1; then
+
+    2>&1 echo "Neither regions nor zones specified - not detected"
+
+    test_failed "${subtest}"
+  else
+
+    assert_output_empty
+
+    assert_err_contains \
+      "ValueError: Exactly one of --regions and --zones must be specified"
+
+    test_passed "${subtest}"
+  fi
+}
+readonly -f test_with_region_and_zone
+
+# Run the tests
+trap "exit_handler" EXIT
+
+mkdir -p "${TEST_TMP}"
+
+echo
+test_with_neither_region_nor_zone
+test_with_region_and_zone

--- a/test/unit/param_util_test.py
+++ b/test/unit/param_util_test.py
@@ -138,11 +138,14 @@ class FileParamUtilTest(unittest.TestCase):
       ('wc', False, 'gs://bucket/f/*', 'gs/bucket/f/*', job_model.P_GCS),
       ('wc', False, '*.bam', 'file/*.bam', job_model.P_LOCAL),
       ('wc', False, '../*', 'file/_dotdot_/*', job_model.P_LOCAL),
+      ('nl', False, '', None, None),
+      ('nl', True, '', None, None),
   ])
   def test_input_file_docker_rewrite(self, unused_name, recursive, uri, docker,
                                      provider):
     del unused_name
-    docker = os.path.join('input', docker)
+    if docker:
+      docker = os.path.join('input', docker)
     file_param_util = param_util.InputFileParamUtil('input')
     param = file_param_util.make_param('TEST', uri, recursive)
     self.assertIsInstance(param, job_model.InputFileParam)
@@ -182,11 +185,14 @@ class FileParamUtilTest(unittest.TestCase):
       ('wc', False, 'gs://bucket/f/*', 'gs/bucket/f/*', job_model.P_GCS),
       ('wc', False, '*.bam', 'file/*.bam', job_model.P_LOCAL),
       ('wc', False, '../*', 'file/_dotdot_/*', job_model.P_LOCAL),
+      ('nl', False, '', None, None),
+      ('nl', True, '', None, None),
   ])
   def test_out_file_docker_rewrite(self, unused_name, recursive, uri, docker,
                                    provider):
     del unused_name
-    docker = os.path.join('output', docker)
+    if docker:
+      docker = os.path.join('output', docker)
     file_param_util = param_util.OutputFileParamUtil('output')
     param = file_param_util.make_param('TEST', uri, recursive)
     self.assertIsInstance(param, job_model.OutputFileParam)


### PR DESCRIPTION
This change includes incremental progress on the Pipelines V2 provider and general refactoring to enable this upcoming feature. Other user visible changes include:

  * Support for empty `--inputs` and `--outputs` from the command line and task files.
  * `dstat` may now includes provider attributes, such as compute region and machine type.